### PR TITLE
Add ScienceDirect body content extraction

### DIFF
--- a/miner/__init__.py
+++ b/miner/__init__.py
@@ -1,0 +1,6 @@
+# minimal package init
+__all__ = [
+    "cli", "io", "text", "embeddings", "cluster",
+    "graph", "graph_build", "themes", "recommend",
+    "bib", "utils", "vis", "badges",
+]

--- a/miner/badges.py
+++ b/miner/badges.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+import numpy as np
+from typing import Any, Dict, List
+
+def compute_badges(docs: List[Dict[str, Any]], degree: List[int],
+                   cluster_sizes: Dict[int, int], labels) -> Dict[str, List[str]]:
+    deg = np.array(degree)
+    hi = np.percentile(deg, 75) if len(deg) else 0
+    badges: Dict[str, List[str]] = {}
+    for i, d in enumerate(docs):
+        b: List[str] = []
+        if d.get("oa") or d.get("pdf_url") or d.get("open_url"):
+            b.append("OA")
+        if degree[i] >= hi:
+            b.append("Highly connected")
+        c = int(labels[i]) if len(labels) > i else 0
+        if cluster_sizes.get(c, 0) <= max(2, int(0.1 * max(1, len(docs)))):
+            b.append("Under‑covered theme")
+        if not (d.get("csl") or {}).get("DOI") and not (d.get("csl") or {}).get("doi"):
+            b.append("Needs metadata")
+        badges[d.get("citekey") or str(i)] = b
+    return badges

--- a/miner/bib.py
+++ b/miner/bib.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+
+def _fmt_authors(auths) -> str:
+    out = []
+    if isinstance(auths, list):
+        for a in auths:
+            if isinstance(a, dict):
+                fam = a.get("family") or ""
+                giv = a.get("given") or ""
+                nm = (str(fam).strip() + ", " + str(giv).strip()).strip(", ").strip()
+                if nm:
+                    out.append(nm)
+            elif isinstance(a, str):
+                s = a.strip()
+                if s:
+                    out.append(s)
+    return " and ".join([a for a in out if a])
+
+def _csl_to_bibtex(csl: Dict[str, Any], fallback_key: str = "ref") -> str:
+    if not isinstance(csl, dict) or not csl:
+        return ""
+    typ = csl.get("type") or "article"
+    key = csl.get("id") or fallback_key
+    fields = []
+    title = csl.get("title") or ""
+    cont = csl.get("container-title") or ""
+    doi = csl.get("DOI") or ""
+    year = None
+    try:
+        year = csl.get("issued", {}).get("date-parts", [[None]])[0][0]
+    except Exception:
+        year = None
+    authors = _fmt_authors(csl.get("author") or [])
+    if title: fields.append(("title", str(title)))
+    if cont: fields.append(("journal", str(cont)))
+    if authors: fields.append(("author", authors))
+    if year: fields.append(("year", str(year)))
+    if doi: fields.append(("doi", str(doi)))
+    for k_from, k_to in [
+        ("volume","volume"), ("issue","number"), ("page","pages"),
+        ("URL","url"), ("publisher","publisher"), ("ISSN","issn")
+    ]:
+        v = csl.get(k_from) or csl.get(k_from.upper())
+        if v: fields.append((k_to, str(v)))
+    body = ",\n".join([f"  {k} = {{{v}}}" for k, v in fields])
+    return f"@{typ}{{{key},\n{body}\n}}"
+
+def aggregate_bib(docs: List[Dict[str, Any]]) -> str:
+    seen = set()
+    out = []
+    for d in docs:
+        for r in (d.get("references") or []):
+            key = r.get("id") or r.get("ref_id") or r.get("doi") or r.get("raw")
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            if r.get("bibtex"):
+                bt = str(r.get("bibtex")).strip()
+                if bt:
+                    out.append(bt)
+                continue
+            csl = r.get("csl") or {}
+            bt = _csl_to_bibtex(csl, fallback_key=str(key))
+            if bt:
+                out.append(bt)
+    return "\n\n".join(out)

--- a/miner/cli.py
+++ b/miner/cli.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+from .io import load_docs
+from .embeddings import compute_embeddings
+from .cluster import kmeans_labels
+from .graph_build import build_graph
+from .themes import label_clusters
+from .recommend import recommend_next
+from .bib import aggregate_bib
+from .utils import safe_json
+from .vis import write_graph_html
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Paperclip miner: cluster + graph + themes + references + recs"
+    )
+    ap.add_argument(
+        "--in", dest="inputs", nargs="+", required=True,
+        help='Input JSON globs (e.g., "artifacts/*/server_parsed.json")'
+    )
+    ap.add_argument("--out", dest="outdir", required=True, help="Output directory")
+    ap.add_argument("--k", dest="k", type=int, default=None,
+                    help="Number of clusters; if omitted, auto-select")
+    ap.add_argument("--knn", dest="knn", type=int, default=7,
+                    help="k for k-NN similarity edges (default 7)")
+    ap.add_argument("--topn", dest="topn", type=int, default=20,
+                    help="Top-N recommendations to output (default 20)")
+    args = ap.parse_args()
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # 1) Load docs
+    docs = load_docs(args.inputs)
+    if not docs:
+        raise SystemExit("No documents found. Check your --in glob(s).")
+
+    # 2) Embeddings
+    X, _payload = compute_embeddings(docs)  # X: (n, d) ndarray
+
+    # 3) Clustering
+    labels, compact = kmeans_labels(X, k=args.k)
+
+    # 4) Graph
+    graph, degree = build_graph(docs, X, labels, k_sim=args.knn)
+    safe_json(graph, outdir / "graph.json")
+
+    # 5) Themes (themes = {clusterId: {label, top_terms, size, ...}})
+    themes, doc_themes = label_clusters(docs, labels)
+    safe_json({"themes": themes, "docThemes": doc_themes}, outdir / "themes.json")
+
+    # 6) Recommendations
+    recs = recommend_next(docs, labels, degree, top_n=args.topn)
+    safe_json({"recommendations": recs}, outdir / "recommendations.json")
+
+    # 7) Aggregate BibTeX
+    (outdir / "references.bib").write_text(aggregate_bib(docs), "utf-8")
+
+    # 8) Self-contained, offline viewer (graph + themes inlined)
+    write_graph_html(graph, themes, outdir / "graph.html")
+
+    # 9) Echo a small summary (stdout)
+    summary = {
+        "n_docs": len(docs),
+        "k": int(len(set(int(x) for x in labels))) if len(labels) else 0,
+        "compactness": float(compact),
+        "graph_nodes": len(graph.get("nodes", [])),
+        "graph_edges": len(graph.get("edges", [])),
+        "themes": len(themes),
+        "top_recs": len(recs),
+    }
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/miner/cluster.py
+++ b/miner/cluster.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import Tuple, Optional
+import numpy as np
+from sklearn.cluster import KMeans
+
+def _auto_k(n: int) -> int:
+    if n <= 1:
+        return 1
+    k = max(1, int(round(np.sqrt(n))))
+    return int(min(max(1, k), min(10, n)))
+
+def kmeans_labels(X: np.ndarray, k: Optional[int] = None, random_state: int = 42) -> Tuple[np.ndarray, float]:
+    n = int(X.shape[0])
+    if n == 0:
+        return np.array([], dtype=int), 0.0
+    if k is None or k < 1 or k > n:
+        k = _auto_k(n)
+    if n < k:
+        k = n
+    if n == 1:
+        return np.array([0], dtype=int), 0.0
+    km = KMeans(n_clusters=k, n_init=10, random_state=random_state)
+    labels = km.fit_predict(X)
+    centers = km.cluster_centers_[labels]
+    dists = np.linalg.norm(X - centers, axis=1)
+    compact = float(dists.mean()) if n else 0.0
+    return labels.astype(int), compact

--- a/miner/clustering.py
+++ b/miner/clustering.py
@@ -1,0 +1,15 @@
+import math
+import numpy as np
+from sklearn.cluster import KMeans
+
+def choose_k(n: int) -> int:
+    # small, robust heuristic
+    return max(2, min(12, round(math.sqrt(max(2, n)))))
+
+def kmeans_cluster(X, k: int | None = None, seed: int = 0):
+    if k is None:
+        k = choose_k(X.shape[0] if hasattr(X, "shape") else X.shape[0])
+    km = KMeans(n_clusters=k, random_state=seed, n_init=10)
+    labels = km.fit_predict(X)
+    centers = getattr(km, "cluster_centers_", None)
+    return labels.tolist(), centers

--- a/miner/codebase.py.txt
+++ b/miner/codebase.py.txt
@@ -1,0 +1,927 @@
+=== START OF: ./loader.py ===
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+@dataclass
+class Document:
+    path: Path
+    id: str
+    title: str
+    doi: str | None
+    url: str | None
+    year: str | None
+    keywords: list[str]
+    text: str
+    references: list[dict]  # items may contain 'doi', 'csl', 'bibtex', 'raw', etc.
+
+def _join_text(content: dict) -> str:
+    # server_parsed.json -> { abstract: [ {body}... ], keywords: [..], body: [sections...] }
+    parts = []
+    for a in content.get("abstract", []) or []:
+        parts.append(a.get("body", ""))
+    for sec in content.get("body", []) or []:
+        parts.append(sec.get("markdown", ""))
+        for p in sec.get("paragraphs", []) or []:
+            parts.append(p.get("markdown", ""))
+    return "\n\n".join(p for p in parts if p)
+
+def load_documents(inputs: list[str]) -> list[Document]:
+    files: list[Path] = []
+    for pattern in inputs:
+        p = Path(pattern)
+        if p.is_file():
+            files.append(p)
+        else:
+            files.extend(Path().glob(pattern))
+    docs: list[Document] = []
+    for fp in sorted(set(files)):
+        with open(fp, "r", encoding="utf-8") as f:
+            obj = json.load(f)
+        meta = obj.get("meta", {})
+        content = obj.get("content", {})
+        docs.append(Document(
+            path=fp,
+            id=obj.get("id") or meta.get("doi") or str(fp),
+            title=meta.get("title") or (meta.get("source") or "Untitled"),
+            doi=(meta.get("doi") or None),
+            url=(obj.get("url") or meta.get("url") or None),
+            year=(meta.get("issued_year") or None),
+            keywords=list(content.get("keywords") or []),
+            text=_join_text(content),
+            references=list(obj.get("references") or []),
+        ))
+    return docs
+=== END OF: ./loader.py ===
+
+=== START OF: ./themes.py ===
+from __future__ import annotations
+from typing import Dict, Any, List, Sequence, Tuple
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+def label_clusters(
+    docs: List[Dict[str, Any]],
+    labels: Sequence[int],
+    top_k: int = 6
+) -> Tuple[Dict[int, Dict[str, Any]], List[str]]:
+    """
+    Build short labels for clusters from TF-IDF top terms.
+    Accepts docs + labels (no external payload required).
+    """
+    n = len(docs)
+    if n == 0:
+        return {}, []
+
+    labels = np.asarray(labels, dtype=int)
+    texts = [(d.get("text") or "") for d in docs]
+
+    vec = TfidfVectorizer(
+        lowercase=True,
+        stop_words="english",
+        ngram_range=(1, 2),
+        max_features=20000,
+        token_pattern=r"(?u)\b[a-zA-Z][a-zA-Z\-]{2,}\b",
+    )
+    # If all texts are empty, avoid ValueError from vectorizer
+    if not any(t.strip() for t in texts):
+        per_doc = ["misc"] * n
+        return {}, per_doc
+
+    X = vec.fit_transform(texts)
+    vocab = np.asarray(vec.get_feature_names_out())
+
+    clusters: Dict[int, Dict[str, Any]] = {}
+
+    for c in np.unique(labels):
+        idx = np.where(labels == c)[0]
+        if idx.size == 0:
+            continue
+        # centroid over sparse rows; mean() yields 1 x F matrix
+        centroid = X[idx].mean(axis=0)
+        arr = np.asarray(centroid).ravel()
+        top_idx = arr.argsort()[-top_k:][::-1]
+        terms = vocab[top_idx].tolist()
+        title = ", ".join(terms[:3])
+        clusters[int(c)] = {
+            "label": title,
+            "top_terms": terms,
+            "size": int(idx.size),
+            "example_titles": [docs[i].get("title") for i in idx[:3]],
+        }
+
+    per_doc = [
+        clusters[int(labels[i])]["label"] if int(labels[i]) in clusters else "misc"
+        for i in range(n)
+    ]
+    return clusters, per_doc
+=== END OF: ./themes.py ===
+
+=== START OF: ./__init__.py ===
+# minimal package init
+__all__ = [
+    "cli", "io", "text", "embeddings", "cluster",
+    "graph", "graph_build", "themes", "recommend",
+    "bib", "utils", "vis", "badges",
+]
+=== END OF: ./__init__.py ===
+
+=== START OF: ./cli.py ===
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+from .io import load_docs
+from .embeddings import compute_embeddings
+from .cluster import kmeans_labels
+from .graph_build import build_graph
+from .themes import label_clusters
+from .recommend import recommend_next
+from .bib import aggregate_bib
+from .utils import safe_json
+from .vis import write_graph_html
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Paperclip miner: cluster + graph + themes + references + recs"
+    )
+    ap.add_argument(
+        "--in", dest="inputs", nargs="+", required=True,
+        help='Input JSON globs (e.g., "artifacts/*/server_parsed.json")'
+    )
+    ap.add_argument("--out", dest="outdir", required=True, help="Output directory")
+    ap.add_argument("--k", dest="k", type=int, default=None,
+                    help="Number of clusters; if omitted, auto-select")
+    ap.add_argument("--knn", dest="knn", type=int, default=7,
+                    help="k for k-NN similarity edges (default 7)")
+    ap.add_argument("--topn", dest="topn", type=int, default=20,
+                    help="Top-N recommendations to output (default 20)")
+    args = ap.parse_args()
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # 1) Load docs
+    docs = load_docs(args.inputs)
+    if not docs:
+        raise SystemExit("No documents found. Check your --in glob(s).")
+
+    # 2) Embeddings
+    X, _payload = compute_embeddings(docs)  # X: (n, d) ndarray
+
+    # 3) Clustering
+    labels, compact = kmeans_labels(X, k=args.k)
+
+    # 4) Graph
+    graph, degree = build_graph(docs, X, labels, k_sim=args.knn)
+    safe_json(graph, outdir / "graph.json")
+
+    # 5) Themes (uses docs+labels; no external payload required)
+    themes, doc_themes = label_clusters(docs, labels)
+    safe_json({"themes": themes, "docThemes": doc_themes}, outdir / "themes.json")
+
+    # 6) Recommendations
+    recs = recommend_next(docs, labels, degree, top_n=args.topn)
+    safe_json({"recommendations": recs}, outdir / "recommendations.json")
+
+    # 7) Aggregate BibTeX
+    (outdir / "references.bib").write_text(aggregate_bib(docs), "utf-8")
+
+    # 8) Tiny, self-contained graph viewer
+    write_graph_html(graph, outdir / "graph.html")
+
+    # 9) Echo a small summary (stdout)
+    summary = {
+        "n_docs": len(docs),
+        "k": int(len(set(int(x) for x in labels))) if len(labels) else 0,
+        "compactness": float(compact),
+        "graph_nodes": len(graph.get("nodes", [])),
+        "graph_edges": len(graph.get("edges", [])),
+        "themes": len(themes),
+        "top_recs": len(recs),
+    }
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+=== END OF: ./cli.py ===
+
+=== START OF: ./badges.py ===
+from __future__ import annotations
+import numpy as np
+from typing import Any, Dict, List
+
+def compute_badges(docs: List[Dict[str, Any]], degree: List[int],
+                   cluster_sizes: Dict[int, int], labels) -> Dict[str, List[str]]:
+    deg = np.array(degree)
+    hi = np.percentile(deg, 75) if len(deg) else 0
+    badges: Dict[str, List[str]] = {}
+    for i, d in enumerate(docs):
+        b: List[str] = []
+        if d.get("oa") or d.get("pdf_url") or d.get("open_url"):
+            b.append("OA")
+        if degree[i] >= hi:
+            b.append("Highly connected")
+        c = int(labels[i]) if len(labels) > i else 0
+        if cluster_sizes.get(c, 0) <= max(2, int(0.1 * max(1, len(docs)))):
+            b.append("Under‑covered theme")
+        if not (d.get("csl") or {}).get("DOI") and not (d.get("csl") or {}).get("doi"):
+            b.append("Needs metadata")
+        badges[d.get("citekey") or str(i)] = b
+    return badges
+=== END OF: ./badges.py ===
+
+=== START OF: ./cluster.py ===
+from __future__ import annotations
+from typing import Tuple, Optional
+import numpy as np
+from sklearn.cluster import KMeans
+
+def _auto_k(n: int) -> int:
+    if n <= 1:
+        return 1
+    k = max(1, int(round(np.sqrt(n))))
+    return int(min(max(1, k), min(10, n)))
+
+def kmeans_labels(X: np.ndarray, k: Optional[int] = None, random_state: int = 42) -> Tuple[np.ndarray, float]:
+    n = int(X.shape[0])
+    if n == 0:
+        return np.array([], dtype=int), 0.0
+    if k is None or k < 1 or k > n:
+        k = _auto_k(n)
+    if n < k:
+        k = n
+    if n == 1:
+        return np.array([0], dtype=int), 0.0
+    km = KMeans(n_clusters=k, n_init=10, random_state=random_state)
+    labels = km.fit_predict(X)
+    centers = km.cluster_centers_[labels]
+    dists = np.linalg.norm(X - centers, axis=1)
+    compact = float(dists.mean()) if n else 0.0
+    return labels.astype(int), compact
+=== END OF: ./cluster.py ===
+
+=== START OF: ./vis.py ===
+from __future__ import annotations
+from pathlib import Path
+import json
+
+_HTML = """<!doctype html>
+<meta charset="utf-8"/>
+<title>Paperclip Graph</title>
+<style>
+  :root { --bar-h: 52px; }
+  * { box-sizing: border-box; }
+  body { margin:0; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  #top { padding:10px; border-bottom:1px solid #ddd; height: var(--bar-h); display:flex; align-items:center; gap:8px; }
+  #graph { width:100vw; height: calc(100vh - var(--bar-h)); display:block; }
+  .badge { display:inline-block; padding:2px 6px; border:1px solid #999; border-radius:3px; font-size:12px; }
+  #msg { position: absolute; top: calc(var(--bar-h) + 10px); left: 10px; background:#fff8c5; border:1px solid #e0c97f; padding:6px 8px; border-radius:4px; display:none; }
+</style>
+<div id="top">
+  <span class="badge" id="count"></span>
+  <span class="badge" id="edges"></span>
+  <span class="badge">Drag to pan • Wheel to zoom</span>
+</div>
+<canvas id="graph"></canvas>
+<div id="msg"></div>
+<script>
+// ---- Inline data (no fetch) ----
+const G = __GRAPH_JSON__;
+const nodes = G.nodes || [];
+const edges = G.edges || [];
+
+// ---- Canvas setup ----
+const canvas = document.getElementById('graph');
+const ctx = canvas.getContext('2d', { alpha: false });
+function resize(){ canvas.width = window.innerWidth; canvas.height = window.innerHeight - parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bar-h')); redraw(); }
+window.addEventListener('resize', resize);
+
+// ---- Badges / empty-state ----
+document.getElementById('count').textContent = nodes.length + ' nodes';
+document.getElementById('edges').textContent = edges.length + ' edges';
+const msg = document.getElementById('msg');
+if (!nodes.length) {
+  msg.textContent = 'No nodes to display (check your input data).';
+  msg.style.display = 'inline-block';
+}
+
+// ---- Simple force layout ----
+function rand(min, max){ return min + Math.random()*(max-min); }
+let pos = Array.from({length:nodes.length}, _=>({x:rand(50, Math.max(60, canvas.width-50)), y:rand(50, Math.max(60, canvas.height-50))}));
+let vel = Array.from({length:nodes.length}, _=>({x:0,y:0}));
+function stepLayout(iters=250){
+  const n = nodes.length; if (!n) return;
+  for(let it=0; it<iters; it++){
+    for(let i=0;i<n;i++){
+      let fx=0, fy=0;
+      for(let j=i+1;j<n;j++){
+        const dx = pos[i].x - pos[j].x, dy = pos[i].y - pos[j].y;
+        const d2 = Math.max(36, dx*dx + dy*dy);
+        const f = 900 / d2; const invd = 1/Math.sqrt(d2);
+        const fxij = f*dx*invd, fyij = f*dy*invd;
+        fx += fxij; fy += fyij;
+        vel[j].x -= fxij; vel[j].y -= fyij;
+      }
+      vel[i].x += fx; vel[i].y += fy;
+    }
+    const k=0.01;
+    for(const e of edges){
+      const i=e.source, j=e.target;
+      const dx = pos[j].x - pos[i].x, dy = pos[j].y - pos[i].y;
+      vel[i].x += k*dx; vel[i].y += k*dy;
+      vel[j].x -= k*dx; vel[j].y -= k*dy;
+    }
+    for(let i=0;i<n;i++){
+      pos[i].x += vel[i].x; pos[i].y += vel[i].y;
+      vel[i].x *= 0.85; vel[i].y *= 0.85;
+    }
+  }
+}
+
+// ---- Render / interactions ----
+let scale = 1, dx = 0, dy = 0, dragging = false, lastX = 0, lastY = 0;
+function redraw(){
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  if (!nodes.length) return;
+  ctx.save(); ctx.translate(dx,dy); ctx.scale(scale,scale);
+  // edges
+  ctx.lineWidth = 1; ctx.strokeStyle = 'rgba(0,0,0,0.15)';
+  for (const e of edges) {
+    const s = pos[e.source], t = pos[e.target];
+    ctx.beginPath(); ctx.moveTo(s.x, s.y); ctx.lineTo(t.x, t.y); ctx.stroke();
+  }
+  // nodes
+  ctx.fillStyle = '#333';
+  for (let i=0;i<nodes.length;i++){
+    const p = pos[i];
+    const r = 4 + ((nodes[i].degree||0)*0.2);
+    ctx.beginPath(); ctx.arc(p.x, p.y, r, 0, Math.PI*2); ctx.fill();
+  }
+  ctx.restore();
+}
+canvas.addEventListener('wheel', e => { e.preventDefault(); const s = Math.exp(-e.deltaY*0.001); scale *= s; redraw(); }, { passive:false });
+canvas.addEventListener('mousedown', e=>{ dragging=true; lastX=e.clientX; lastY=e.clientY; });
+canvas.addEventListener('mousemove', e=>{ if(!dragging) return; dx += (e.clientX - lastX); dy += (e.clientY - lastY); lastX=e.clientX; lastY=e.clientY; redraw(); });
+['mouseup','mouseleave'].forEach(ev=>canvas.addEventListener(ev, ()=> dragging=false));
+
+// ---- Boot ----
+resize();
+stepLayout(300);
+redraw();
+</script>
+"""
+
+def _escape_for_script(s: str) -> str:
+    # Avoid closing the <script> tag from inside JSON (e.g., in titles)
+    return s.replace("</", "<\\/").replace("<!--", "<\\!--")
+
+def write_graph_html(graph: dict, out_html: Path):
+    # Embed the graph directly in the HTML (works when opened via file://)
+    data = json.dumps(graph, ensure_ascii=False)
+    html = _HTML.replace("__GRAPH_JSON__", _escape_for_script(data))
+    out_html.write_text(html, encoding="utf-8")
+=== END OF: ./vis.py ===
+
+=== START OF: ./io.py ===
+from __future__ import annotations
+from pathlib import Path
+import json
+from typing import List, Dict, Any
+from .text import extract_text
+from .utils import slugify
+
+def _one_doc(fp: Path) -> Dict[str, Any]:
+    obj = json.loads(fp.read_text(encoding="utf-8"))
+    meta = obj.get("meta", {}) or {}
+    content = obj.get("content", {}) or {}
+    title = meta.get("title") or meta.get("source") or "Untitled"
+    doi = meta.get("doi") or None
+    url = obj.get("url") or meta.get("url") or None
+    year = str(meta.get("issued_year")) if meta.get("issued_year") else None
+    keywords = list(content.get("keywords") or [])
+    text = extract_text(content)
+    references = list(obj.get("references") or [])
+
+    # Choose a stable id and citekey
+    id_ = obj.get("id") or doi or str(fp)
+    citekey = meta.get("citekey") or (slugify(title) if not doi else slugify(doi))
+
+    return {
+        "path": str(fp),
+        "id": id_,
+        "title": title,
+        "doi": doi,
+        "url": url,
+        "year": year,
+        "keywords": keywords,
+        "text": text,
+        "references": references,
+        "citekey": citekey,
+        "meta": meta,
+        "csl": meta.get("csl") or None,
+    }
+
+def load_docs(input_patterns: List[str]) -> List[Dict[str, Any]]:
+    files: List[Path] = []
+    for pattern in input_patterns:
+        p = Path(pattern)
+        if p.is_file():
+            files.append(p)
+        else:
+            files.extend(Path().glob(pattern))
+    seen = set()
+    out: List[Dict[str, Any]] = []
+    for fp in sorted(set(files)):
+        try:
+            d = _one_doc(fp)
+        except Exception as e:
+            print(f"[WARN] Failed to read {fp}: {e}")
+            continue
+        key = d["doi"] or d["id"]
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+=== END OF: ./io.py ===
+
+=== START OF: ./text.py ===
+from __future__ import annotations
+from typing import Any, Dict, List
+from .utils import normalize_title
+
+def text_for_embedding(doc: Dict[str, Any]) -> str:
+    csl = doc.get("csl") or {}
+    parts: List[str] = []
+    for key in ("title", "abstract", "abstractText"):
+        v = csl.get(key) if isinstance(csl, dict) else None
+        if isinstance(v, str) and v.strip():
+            parts.append(v.strip())
+    # Fallbacks from parsed payload
+    if not parts and isinstance(doc.get("title"), str):
+        parts.append(doc["title"])
+    if isinstance(doc.get("headings"), list):
+        parts.extend([h for h in doc["headings"] if isinstance(h, str)])
+    # As a last resort, compress visible text sample if present
+    if isinstance(doc.get("text_sample"), str):
+        parts.append(doc["text_sample"][:2000])
+    return "\n".join(parts).strip()
+
+def references_from_doc(doc: Dict[str, Any]) -> List[Dict[str, Any]]:
+    refs = doc.get("references") or []
+    out: List[Dict[str, Any]] = []
+    for r in refs:
+        if not isinstance(r, dict):
+            continue
+        out.append({
+            "doi": r.get("doi") or r.get("DOI") or "",
+            "title": (r.get("title") or r.get("unstructured") or "").strip(),
+        })
+    return out
+
+def title_of(doc: Dict[str, Any]) -> str:
+    csl = doc.get("csl") or {}
+    title = csl.get("title") if isinstance(csl, dict) else None
+    return (title or doc.get("title") or "").strip()
+
+def norm_title_of(doc: Dict[str, Any]) -> str:
+    return normalize_title(title_of(doc))
+
+def extract_text(content: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    for a in (content.get("abstract") or []):
+        parts.append(a.get("body") or "")
+    for sec in (content.get("body") or []):
+        if sec.get("markdown"):
+            parts.append(sec["markdown"])
+        for p in (sec.get("paragraphs") or []):
+            if p.get("markdown"):
+                parts.append(p["markdown"])
+    # Fallbacks
+    if not parts and content.get("fulltext"):
+        parts.append(content["fulltext"])
+    return "\n\n".join(p for p in parts if p).strip()
+=== END OF: ./text.py ===
+
+=== START OF: ./graph_build.py ===
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple
+import numpy as np
+from .graph import knn_edges
+
+def build_graph(docs: List[Dict[str, Any]], X: np.ndarray, labels, k_sim: int = 7):
+    n = len(docs)
+    edges = knn_edges(X, k=k_sim) if n > 1 else []
+    degree = [0] * n
+    for i, j, _ in edges:
+        degree[i] += 1
+        degree[j] += 1
+    nodes = []
+    for i, d in enumerate(docs):
+        nodes.append({
+            "id": i,
+            "docId": d.get("id") or d.get("citekey"),
+            "title": d.get("title"),
+            "citekey": d.get("citekey"),
+            "clusterId": int(labels[i]) if len(labels) > i else 0,
+            "degree": degree[i],
+            "doi": (d.get("meta") or {}).get("doi") or (d.get("csl") or {}).get("DOI"),
+            "url": d.get("url") or (d.get("meta") or {}).get("url"),
+        })
+    graph = {
+        "nodes": nodes,
+        "edges": [{"source": i, "target": j, "weight": w} for i, j, w in edges],
+    }
+    return graph, degree
+=== END OF: ./graph_build.py ===
+
+=== START OF: ./embeddings.py ===
+from __future__ import annotations
+from typing import List, Dict, Any, Tuple, Optional
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.decomposition import TruncatedSVD
+from sklearn.preprocessing import Normalizer
+
+
+def compute_embeddings(
+    docs: List[Dict[str, Any]], dim: int = 256
+) -> Tuple[np.ndarray, Optional[dict]]:
+    """
+    Robust TF-IDF -> SVD (LSA) -> L2 normalization.
+    Returns:
+      X: (n, d) float32 matrix
+      payload: dict with fitted vectorizer/svd/normalizer for optional reuse
+    """
+    texts = [(d.get("text") or "") for d in docs]
+
+    if len(texts) == 0:
+        return np.zeros((0, 0), dtype=np.float32), None
+
+    tfidf = TfidfVectorizer(
+        lowercase=True,
+        stop_words="english",
+        ngram_range=(1, 2),
+        max_df=0.9,
+        min_df=1,
+        token_pattern=r"(?u)\b[a-zA-Z][a-zA-Z\-]{2,}\b",
+    )
+    X_tfidf = tfidf.fit_transform(texts)
+    n_samples, n_features = X_tfidf.shape
+
+    if n_samples <= 1 or n_features <= 2:
+        # Degenerate small case: return normalized TF-IDF rows
+        X = X_tfidf.astype(np.float32)
+        norms = np.sqrt((X.multiply(X)).sum(axis=1)).A1 + 1e-8
+        X = X.multiply(1.0 / norms[:, None]).toarray().astype(np.float32)
+        return X, {"vectorizer": tfidf, "svd": None, "normalizer": None}
+
+    n_components = max(2, min(dim, 256, n_samples - 1, n_features - 1))
+    svd = TruncatedSVD(n_components=n_components, random_state=0)
+    X_lsa = svd.fit_transform(X_tfidf)
+    normalizer = Normalizer(copy=False)
+    X = normalizer.fit_transform(X_lsa).astype(np.float32)
+
+    payload = {"vectorizer": tfidf, "svd": svd, "normalizer": normalizer}
+    return X, payload
+=== END OF: ./embeddings.py ===
+
+=== START OF: ./bib.py ===
+from __future__ import annotations
+from typing import Dict, Any, List
+
+def _fmt_authors(auths) -> str:
+    out = []
+    if isinstance(auths, list):
+        for a in auths:
+            if isinstance(a, dict):
+                fam = a.get("family") or ""
+                giv = a.get("given") or ""
+                nm = (str(fam).strip() + ", " + str(giv).strip()).strip(", ").strip()
+                if nm:
+                    out.append(nm)
+            elif isinstance(a, str):
+                s = a.strip()
+                if s:
+                    out.append(s)
+    return " and ".join([a for a in out if a])
+
+def _csl_to_bibtex(csl: Dict[str, Any], fallback_key: str = "ref") -> str:
+    if not isinstance(csl, dict) or not csl:
+        return ""
+    typ = csl.get("type") or "article"
+    key = csl.get("id") or fallback_key
+    fields = []
+    title = csl.get("title") or ""
+    cont = csl.get("container-title") or ""
+    doi = csl.get("DOI") or ""
+    year = None
+    try:
+        year = csl.get("issued", {}).get("date-parts", [[None]])[0][0]
+    except Exception:
+        year = None
+    authors = _fmt_authors(csl.get("author") or [])
+    if title: fields.append(("title", str(title)))
+    if cont: fields.append(("journal", str(cont)))
+    if authors: fields.append(("author", authors))
+    if year: fields.append(("year", str(year)))
+    if doi: fields.append(("doi", str(doi)))
+    for k_from, k_to in [
+        ("volume","volume"), ("issue","number"), ("page","pages"),
+        ("URL","url"), ("publisher","publisher"), ("ISSN","issn")
+    ]:
+        v = csl.get(k_from) or csl.get(k_from.upper())
+        if v: fields.append((k_to, str(v)))
+    body = ",\n".join([f"  {k} = {{{v}}}" for k, v in fields])
+    return f"@{typ}{{{key},\n{body}\n}}"
+
+def aggregate_bib(docs: List[Dict[str, Any]]) -> str:
+    seen = set()
+    out = []
+    for d in docs:
+        for r in (d.get("references") or []):
+            key = r.get("id") or r.get("ref_id") or r.get("doi") or r.get("raw")
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            if r.get("bibtex"):
+                bt = str(r.get("bibtex")).strip()
+                if bt:
+                    out.append(bt)
+                continue
+            csl = r.get("csl") or {}
+            bt = _csl_to_bibtex(csl, fallback_key=str(key))
+            if bt:
+                out.append(bt)
+    return "\n\n".join(out)
+=== END OF: ./bib.py ===
+
+=== START OF: ./clustering.py ===
+import math
+import numpy as np
+from sklearn.cluster import KMeans
+
+def choose_k(n: int) -> int:
+    # small, robust heuristic
+    return max(2, min(12, round(math.sqrt(max(2, n)))))
+
+def kmeans_cluster(X, k: int | None = None, seed: int = 0):
+    if k is None:
+        k = choose_k(X.shape[0] if hasattr(X, "shape") else X.shape[0])
+    km = KMeans(n_clusters=k, random_state=seed, n_init=10)
+    labels = km.fit_predict(X)
+    centers = getattr(km, "cluster_centers_", None)
+    return labels.tolist(), centers
+=== END OF: ./clustering.py ===
+
+=== START OF: ./recommend.py ===
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple, Optional
+import numpy as np
+from collections import Counter
+from .utils import normalize_title
+
+
+def _canon_ref_key(r: Dict[str, Any]) -> Optional[str]:
+    """
+    Canonicalize a reference to a stable key using DOI if present;
+    otherwise a normalized title/unstructured field.
+    """
+    if not isinstance(r, dict):
+        return None
+    doi = (r.get("doi") or (r.get("csl") or {}).get("DOI") or "").strip().lower()
+    if doi:
+        return f"doi:{doi}"
+    title = (
+        r.get("title")
+        or (r.get("csl") or {}).get("title")
+        or r.get("unstructured")
+        or ""
+    )
+    t = normalize_title(title)
+    return f"title:{t}" if t else None
+
+
+def score_docs(
+    docs: List[Dict[str, Any]],
+    degree: List[int],
+    labels: np.ndarray,
+    X: np.ndarray
+) -> List[Tuple[int, float]]:
+    """
+    Lightweight 'importance' score across your set (not used by CLI
+    for fetching external refs; kept for ranking within-set).
+    """
+    n = len(docs)
+    if n == 0:
+        return []
+    deg = np.asarray(degree, dtype=float)
+    if deg.size and deg.max() > 0:
+        deg = deg / deg.max()
+
+    unique, counts = np.unique(labels, return_counts=True)
+    cluster_counts = {int(u): int(c) for u, c in zip(unique, counts)}
+    cluster_penalty = np.array(
+        [1.0 / max(1, cluster_counts.get(int(labels[i]), 1)) for i in range(n)]
+    )
+    # Prefer items with less obvious metadata gaps (no abstract etc.)
+    has_abs = np.array([
+        1.0 if ((docs[i].get("csl") or {}).get("abstract") or (docs[i].get("text") or "")) else 0.0
+        for i in range(n)
+    ])
+    score = 0.5 * deg + 0.35 * cluster_penalty + 0.15 * (1.0 - has_abs)
+    ranked = sorted([(i, float(score[i])) for i in range(n)],
+                    key=lambda t: t[1], reverse=True)
+    return ranked
+
+
+def recommended_list(
+    docs: List[Dict[str, Any]],
+    degree: List[int],
+    labels: np.ndarray,
+    X: np.ndarray,
+    k: int = 8
+) -> List[Dict[str, Any]]:
+    ranked = score_docs(docs, degree, labels, X)
+    out = []
+    for i, s in ranked[:k]:
+        d = docs[i]
+        out.append({
+            "id": d.get("id") or d.get("citekey"),
+            "title": d.get("title"),
+            "doi": (d.get("meta") or {}).get("doi") or (d.get("csl") or {}).get("DOI"),
+            "url": d.get("url") or (d.get("meta") or {}).get("url"),
+            "score": round(float(s), 4),
+        })
+    return out
+
+
+def recommend_next(
+    docs: List[Dict[str, Any]],
+    labels,
+    degree: List[int],
+    top_n: int = 20
+) -> List[Dict[str, Any]]:
+    """
+    Suggest full-texts to fetch next: references cited across your set
+    but not yet included in your set (by DOI or normalized title).
+    """
+    have = set((d.get("doi") or "").strip().lower() for d in docs if d.get("doi"))
+    have_titles = set((d.get("title") or "").strip().lower() for d in docs if d.get("title"))
+
+    counts = Counter()
+    ref_map: Dict[str, Dict[str, Any]] = {}
+
+    for d in docs:
+        for r in (d.get("references") or []):
+            key = _canon_ref_key(r)
+            if not key:
+                continue
+            counts[key] += 1
+            # keep the richest representation we've seen
+            if key not in ref_map or len(str(r)) > len(str(ref_map[key])):
+                ref_map[key] = r
+
+    # filter out refs we already have
+    cand: List[Dict[str, Any]] = []
+    for key, freq in counts.most_common():
+        r = ref_map[key]
+        r_doi = (r.get("doi") or (r.get("csl") or {}).get("DOI") or "").strip().lower()
+        r_title = (
+            (r.get("title") or (r.get("csl") or {}).get("title") or "")
+            .strip()
+            .lower()
+        )
+        if (r_doi and r_doi in have) or (r_title and r_title in have_titles):
+            continue
+        cand.append({
+            "title": r.get("title") or (r.get("csl") or {}).get("title") or r.get("unstructured"),
+            "doi": r.get("doi") or (r.get("csl") or {}).get("DOI"),
+            "reason": f"cited {freq}× across your notes",
+            "raw": r,
+        })
+        if len(cand) >= top_n:
+            break
+    return cand
+=== END OF: ./recommend.py ===
+
+=== START OF: ./utils.py ===
+from __future__ import annotations
+from pathlib import Path
+import json
+import re
+import unicodedata
+from typing import Optional, Iterable, Any
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+def html_to_text(html: Optional[str]) -> str:
+    if not html:
+        return ""
+    txt = _HTML_TAG_RE.sub(" ", html)
+    return _WS_RE.sub(" ", txt).strip()
+
+def uniq(seq: Iterable[Any]) -> list:
+    seen = set()
+    out = []
+    for x in seq:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+def slug(s: str, maxlen: int = 48) -> str:
+    s = (s or "").strip()
+    s = re.sub(r"[^A-Za-z0-9]+", "-", s).strip("-")
+    if len(s) > maxlen:
+        s = s[:maxlen].rstrip("-")
+    return s.lower() or "item"
+
+def normalize_title(s: str) -> str:
+    s = (s or "").strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    s = re.sub(r"[^\w\s\-:]+", "", s)
+    return s
+
+def safe_json(obj, path: Path):
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), "utf-8")
+
+def slugify(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", s).strip("-").lower()
+    return s or "item"
+=== END OF: ./utils.py ===
+
+=== START OF: ./graph.py ===
+from __future__ import annotations
+from typing import List, Tuple
+import numpy as np
+
+def cosine_sim_matrix(X: np.ndarray) -> np.ndarray:
+    if X.size == 0:
+        return np.zeros((0, 0), dtype=np.float32)
+    norms = np.linalg.norm(X, axis=1, keepdims=True) + 1e-9
+    Y = X / norms
+    return (Y @ Y.T).astype(np.float32)
+
+def knn_edges(X: np.ndarray, k: int = 7) -> List[Tuple[int, int, float]]:
+    n = int(X.shape[0])
+    if n <= 1:
+        return []
+    k = int(max(1, min(k, n - 1)))
+    sims = cosine_sim_matrix(X)
+    edges = []
+    for i in range(n):
+        row = sims[i].copy()
+        row[i] = -1.0
+        idx = np.argpartition(row, -k)[-k:]
+        idx = idx[np.argsort(row[idx])[::-1]]
+        for j in idx:
+            if i < j:
+                edges.append((i, int(j), float(row[int(j)])))
+    return edges
+=== END OF: ./graph.py ===
+
+=== START OF: ./embed.py ===
+from __future__ import annotations
+import numpy as np
+from typing import List, Tuple
+from .text import text_for_embedding
+
+class Embedder:
+    """
+    Tries sentence-transformers; falls back to TF-IDF if not available.
+    """
+    def __init__(self, model: str | None = None):
+        self.backend = "tfidf"
+        self.model_name = model or "sentence-transformers/all-MiniLM-L6-v2"
+        self._model = None
+        self._tfidf = None
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+            self._model = SentenceTransformer(self.model_name)
+            self.backend = "sbert"
+        except Exception:
+            self._model = None
+
+    def fit_transform(self, docs: List[dict]) -> Tuple[np.ndarray, List[str]]:
+        texts = [text_for_embedding(d) for d in docs]
+        if self._model is not None:
+            X = np.asarray(self._model.encode(texts, normalize_embeddings=True))
+            return X, texts
+        # TF-IDF fallback
+        from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore
+        self._tfidf = TfidfVectorizer(max_features=2048, ngram_range=(1,2))
+        Xs = self._tfidf.fit_transform(texts)
+        # L2 normalize to approximate cosine
+        X = Xs.astype("float32")
+        norms = np.sqrt((X.multiply(X)).sum(axis=1)).A1 + 1e-8
+        X = X.multiply(1.0 / norms[:, None])
+        return X.toarray(), texts
+=== END OF: ./embed.py ===
+

--- a/miner/embed.py
+++ b/miner/embed.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import numpy as np
+from typing import List, Tuple
+from .text import text_for_embedding
+
+class Embedder:
+    """
+    Tries sentence-transformers; falls back to TF-IDF if not available.
+    """
+    def __init__(self, model: str | None = None):
+        self.backend = "tfidf"
+        self.model_name = model or "sentence-transformers/all-MiniLM-L6-v2"
+        self._model = None
+        self._tfidf = None
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+            self._model = SentenceTransformer(self.model_name)
+            self.backend = "sbert"
+        except Exception:
+            self._model = None
+
+    def fit_transform(self, docs: List[dict]) -> Tuple[np.ndarray, List[str]]:
+        texts = [text_for_embedding(d) for d in docs]
+        if self._model is not None:
+            X = np.asarray(self._model.encode(texts, normalize_embeddings=True))
+            return X, texts
+        # TF-IDF fallback
+        from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore
+        self._tfidf = TfidfVectorizer(max_features=2048, ngram_range=(1,2))
+        Xs = self._tfidf.fit_transform(texts)
+        # L2 normalize to approximate cosine
+        X = Xs.astype("float32")
+        norms = np.sqrt((X.multiply(X)).sum(axis=1)).A1 + 1e-8
+        X = X.multiply(1.0 / norms[:, None])
+        return X.toarray(), texts

--- a/miner/embeddings.py
+++ b/miner/embeddings.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Tuple, Optional
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.decomposition import TruncatedSVD
+from sklearn.preprocessing import Normalizer
+
+
+def compute_embeddings(
+    docs: List[Dict[str, Any]], dim: int = 256
+) -> Tuple[np.ndarray, Optional[dict]]:
+    """
+    Robust TF-IDF -> SVD (LSA) -> L2 normalization.
+    Returns:
+      X: (n, d) float32 matrix
+      payload: dict with fitted vectorizer/svd/normalizer for optional reuse
+    """
+    texts = [(d.get("text") or "") for d in docs]
+
+    if len(texts) == 0:
+        return np.zeros((0, 0), dtype=np.float32), None
+
+    tfidf = TfidfVectorizer(
+        lowercase=True,
+        stop_words="english",
+        ngram_range=(1, 2),
+        max_df=0.9,
+        min_df=1,
+        token_pattern=r"(?u)\b[a-zA-Z][a-zA-Z\-]{2,}\b",
+    )
+    X_tfidf = tfidf.fit_transform(texts)
+    n_samples, n_features = X_tfidf.shape
+
+    if n_samples <= 1 or n_features <= 2:
+        # Degenerate small case: return normalized TF-IDF rows
+        X = X_tfidf.astype(np.float32)
+        norms = np.sqrt((X.multiply(X)).sum(axis=1)).A1 + 1e-8
+        X = X.multiply(1.0 / norms[:, None]).toarray().astype(np.float32)
+        return X, {"vectorizer": tfidf, "svd": None, "normalizer": None}
+
+    n_components = max(2, min(dim, 256, n_samples - 1, n_features - 1))
+    svd = TruncatedSVD(n_components=n_components, random_state=0)
+    X_lsa = svd.fit_transform(X_tfidf)
+    normalizer = Normalizer(copy=False)
+    X = normalizer.fit_transform(X_lsa).astype(np.float32)
+
+    payload = {"vectorizer": tfidf, "svd": svd, "normalizer": normalizer}
+    return X, payload

--- a/miner/graph.py
+++ b/miner/graph.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import List, Tuple
+import numpy as np
+
+def cosine_sim_matrix(X: np.ndarray) -> np.ndarray:
+    if X.size == 0:
+        return np.zeros((0, 0), dtype=np.float32)
+    norms = np.linalg.norm(X, axis=1, keepdims=True) + 1e-9
+    Y = X / norms
+    return (Y @ Y.T).astype(np.float32)
+
+def knn_edges(X: np.ndarray, k: int = 7) -> List[Tuple[int, int, float]]:
+    n = int(X.shape[0])
+    if n <= 1:
+        return []
+    k = int(max(1, min(k, n - 1)))
+    sims = cosine_sim_matrix(X)
+    edges = []
+    for i in range(n):
+        row = sims[i].copy()
+        row[i] = -1.0
+        idx = np.argpartition(row, -k)[-k:]
+        idx = idx[np.argsort(row[idx])[::-1]]
+        for j in idx:
+            if i < j:
+                edges.append((i, int(j), float(row[int(j)])))
+    return edges

--- a/miner/graph_build.py
+++ b/miner/graph_build.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple
+import numpy as np
+from .graph import knn_edges
+
+def build_graph(docs: List[Dict[str, Any]], X: np.ndarray, labels, k_sim: int = 7):
+    n = len(docs)
+    edges = knn_edges(X, k=k_sim) if n > 1 else []
+    degree = [0] * n
+    for i, j, _ in edges:
+        degree[i] += 1
+        degree[j] += 1
+    nodes = []
+    for i, d in enumerate(docs):
+        nodes.append({
+            "id": i,
+            "docId": d.get("id") or d.get("citekey"),
+            "title": d.get("title"),
+            "citekey": d.get("citekey"),
+            "clusterId": int(labels[i]) if len(labels) > i else 0,
+            "degree": degree[i],
+            "doi": (d.get("meta") or {}).get("doi") or (d.get("csl") or {}).get("DOI"),
+            "url": d.get("url") or (d.get("meta") or {}).get("url"),
+        })
+    graph = {
+        "nodes": nodes,
+        "edges": [{"source": i, "target": j, "weight": w} for i, j, w in edges],
+    }
+    return graph, degree

--- a/miner/io.py
+++ b/miner/io.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+from typing import List, Dict, Any
+from .text import extract_text
+from .utils import slugify
+
+def _one_doc(fp: Path) -> Dict[str, Any]:
+    obj = json.loads(fp.read_text(encoding="utf-8"))
+    meta = obj.get("meta", {}) or {}
+    content = obj.get("content", {}) or {}
+    title = meta.get("title") or meta.get("source") or "Untitled"
+    doi = meta.get("doi") or None
+    url = obj.get("url") or meta.get("url") or None
+    year = str(meta.get("issued_year")) if meta.get("issued_year") else None
+    keywords = list(content.get("keywords") or [])
+    text = extract_text(content)
+    references = list(obj.get("references") or [])
+
+    # Choose a stable id and citekey
+    id_ = obj.get("id") or doi or str(fp)
+    citekey = meta.get("citekey") or (slugify(title) if not doi else slugify(doi))
+
+    return {
+        "path": str(fp),
+        "id": id_,
+        "title": title,
+        "doi": doi,
+        "url": url,
+        "year": year,
+        "keywords": keywords,
+        "text": text,
+        "references": references,
+        "citekey": citekey,
+        "meta": meta,
+        "csl": meta.get("csl") or None,
+    }
+
+def load_docs(input_patterns: List[str]) -> List[Dict[str, Any]]:
+    files: List[Path] = []
+    for pattern in input_patterns:
+        p = Path(pattern)
+        if p.is_file():
+            files.append(p)
+        else:
+            files.extend(Path().glob(pattern))
+    seen = set()
+    out: List[Dict[str, Any]] = []
+    for fp in sorted(set(files)):
+        try:
+            d = _one_doc(fp)
+        except Exception as e:
+            print(f"[WARN] Failed to read {fp}: {e}")
+            continue
+        key = d["doi"] or d["id"]
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out

--- a/miner/loader.py
+++ b/miner/loader.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+@dataclass
+class Document:
+    path: Path
+    id: str
+    title: str
+    doi: str | None
+    url: str | None
+    year: str | None
+    keywords: list[str]
+    text: str
+    references: list[dict]  # items may contain 'doi', 'csl', 'bibtex', 'raw', etc.
+
+def _join_text(content: dict) -> str:
+    # server_parsed.json -> { abstract: [ {body}... ], keywords: [..], body: [sections...] }
+    parts = []
+    for a in content.get("abstract", []) or []:
+        parts.append(a.get("body", ""))
+    for sec in content.get("body", []) or []:
+        parts.append(sec.get("markdown", ""))
+        for p in sec.get("paragraphs", []) or []:
+            parts.append(p.get("markdown", ""))
+    return "\n\n".join(p for p in parts if p)
+
+def load_documents(inputs: list[str]) -> list[Document]:
+    files: list[Path] = []
+    for pattern in inputs:
+        p = Path(pattern)
+        if p.is_file():
+            files.append(p)
+        else:
+            files.extend(Path().glob(pattern))
+    docs: list[Document] = []
+    for fp in sorted(set(files)):
+        with open(fp, "r", encoding="utf-8") as f:
+            obj = json.load(f)
+        meta = obj.get("meta", {})
+        content = obj.get("content", {})
+        docs.append(Document(
+            path=fp,
+            id=obj.get("id") or meta.get("doi") or str(fp),
+            title=meta.get("title") or (meta.get("source") or "Untitled"),
+            doi=(meta.get("doi") or None),
+            url=(obj.get("url") or meta.get("url") or None),
+            year=(meta.get("issued_year") or None),
+            keywords=list(content.get("keywords") or []),
+            text=_join_text(content),
+            references=list(obj.get("references") or []),
+        ))
+    return docs

--- a/miner/recommend.py
+++ b/miner/recommend.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple, Optional
+import numpy as np
+from collections import Counter
+from .utils import normalize_title
+
+
+def _canon_ref_key(r: Dict[str, Any]) -> Optional[str]:
+    """
+    Canonicalize a reference to a stable key using DOI if present;
+    otherwise a normalized title/unstructured field.
+    """
+    if not isinstance(r, dict):
+        return None
+    doi = (r.get("doi") or (r.get("csl") or {}).get("DOI") or "").strip().lower()
+    if doi:
+        return f"doi:{doi}"
+    title = (
+        r.get("title")
+        or (r.get("csl") or {}).get("title")
+        or r.get("unstructured")
+        or ""
+    )
+    t = normalize_title(title)
+    return f"title:{t}" if t else None
+
+
+def score_docs(
+    docs: List[Dict[str, Any]],
+    degree: List[int],
+    labels: np.ndarray,
+    X: np.ndarray
+) -> List[Tuple[int, float]]:
+    """
+    Lightweight 'importance' score across your set (not used by CLI
+    for fetching external refs; kept for ranking within-set).
+    """
+    n = len(docs)
+    if n == 0:
+        return []
+    deg = np.asarray(degree, dtype=float)
+    if deg.size and deg.max() > 0:
+        deg = deg / deg.max()
+
+    unique, counts = np.unique(labels, return_counts=True)
+    cluster_counts = {int(u): int(c) for u, c in zip(unique, counts)}
+    cluster_penalty = np.array(
+        [1.0 / max(1, cluster_counts.get(int(labels[i]), 1)) for i in range(n)]
+    )
+    # Prefer items with less obvious metadata gaps (no abstract etc.)
+    has_abs = np.array([
+        1.0 if ((docs[i].get("csl") or {}).get("abstract") or (docs[i].get("text") or "")) else 0.0
+        for i in range(n)
+    ])
+    score = 0.5 * deg + 0.35 * cluster_penalty + 0.15 * (1.0 - has_abs)
+    ranked = sorted([(i, float(score[i])) for i in range(n)],
+                    key=lambda t: t[1], reverse=True)
+    return ranked
+
+
+def recommended_list(
+    docs: List[Dict[str, Any]],
+    degree: List[int],
+    labels: np.ndarray,
+    X: np.ndarray,
+    k: int = 8
+) -> List[Dict[str, Any]]:
+    ranked = score_docs(docs, degree, labels, X)
+    out = []
+    for i, s in ranked[:k]:
+        d = docs[i]
+        out.append({
+            "id": d.get("id") or d.get("citekey"),
+            "title": d.get("title"),
+            "doi": (d.get("meta") or {}).get("doi") or (d.get("csl") or {}).get("DOI"),
+            "url": d.get("url") or (d.get("meta") or {}).get("url"),
+            "score": round(float(s), 4),
+        })
+    return out
+
+
+def recommend_next(
+    docs: List[Dict[str, Any]],
+    labels,
+    degree: List[int],
+    top_n: int = 20
+) -> List[Dict[str, Any]]:
+    """
+    Suggest full-texts to fetch next: references cited across your set
+    but not yet included in your set (by DOI or normalized title).
+    """
+    have = set((d.get("doi") or "").strip().lower() for d in docs if d.get("doi"))
+    have_titles = set((d.get("title") or "").strip().lower() for d in docs if d.get("title"))
+
+    counts = Counter()
+    ref_map: Dict[str, Dict[str, Any]] = {}
+
+    for d in docs:
+        for r in (d.get("references") or []):
+            key = _canon_ref_key(r)
+            if not key:
+                continue
+            counts[key] += 1
+            # keep the richest representation we've seen
+            if key not in ref_map or len(str(r)) > len(str(ref_map[key])):
+                ref_map[key] = r
+
+    # filter out refs we already have
+    cand: List[Dict[str, Any]] = []
+    for key, freq in counts.most_common():
+        r = ref_map[key]
+        r_doi = (r.get("doi") or (r.get("csl") or {}).get("DOI") or "").strip().lower()
+        r_title = (
+            (r.get("title") or (r.get("csl") or {}).get("title") or "")
+            .strip()
+            .lower()
+        )
+        if (r_doi and r_doi in have) or (r_title and r_title in have_titles):
+            continue
+        cand.append({
+            "title": r.get("title") or (r.get("csl") or {}).get("title") or r.get("unstructured"),
+            "doi": r.get("doi") or (r.get("csl") or {}).get("DOI"),
+            "reason": f"cited {freq}× across your notes",
+            "raw": r,
+        })
+        if len(cand) >= top_n:
+            break
+    return cand

--- a/miner/text.py
+++ b/miner/text.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+from .utils import normalize_title
+
+def text_for_embedding(doc: Dict[str, Any]) -> str:
+    csl = doc.get("csl") or {}
+    parts: List[str] = []
+    for key in ("title", "abstract", "abstractText"):
+        v = csl.get(key) if isinstance(csl, dict) else None
+        if isinstance(v, str) and v.strip():
+            parts.append(v.strip())
+    # Fallbacks from parsed payload
+    if not parts and isinstance(doc.get("title"), str):
+        parts.append(doc["title"])
+    if isinstance(doc.get("headings"), list):
+        parts.extend([h for h in doc["headings"] if isinstance(h, str)])
+    # As a last resort, compress visible text sample if present
+    if isinstance(doc.get("text_sample"), str):
+        parts.append(doc["text_sample"][:2000])
+    return "\n".join(parts).strip()
+
+def references_from_doc(doc: Dict[str, Any]) -> List[Dict[str, Any]]:
+    refs = doc.get("references") or []
+    out: List[Dict[str, Any]] = []
+    for r in refs:
+        if not isinstance(r, dict):
+            continue
+        out.append({
+            "doi": r.get("doi") or r.get("DOI") or "",
+            "title": (r.get("title") or r.get("unstructured") or "").strip(),
+        })
+    return out
+
+def title_of(doc: Dict[str, Any]) -> str:
+    csl = doc.get("csl") or {}
+    title = csl.get("title") if isinstance(csl, dict) else None
+    return (title or doc.get("title") or "").strip()
+
+def norm_title_of(doc: Dict[str, Any]) -> str:
+    return normalize_title(title_of(doc))
+
+def extract_text(content: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    for a in (content.get("abstract") or []):
+        parts.append(a.get("body") or "")
+    for sec in (content.get("body") or []):
+        if sec.get("markdown"):
+            parts.append(sec["markdown"])
+        for p in (sec.get("paragraphs") or []):
+            if p.get("markdown"):
+                parts.append(p["markdown"])
+    # Fallbacks
+    if not parts and content.get("fulltext"):
+        parts.append(content["fulltext"])
+    return "\n\n".join(p for p in parts if p).strip()

--- a/miner/themes.py
+++ b/miner/themes.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from typing import Dict, Any, List, Sequence, Tuple
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+def label_clusters(
+    docs: List[Dict[str, Any]],
+    labels: Sequence[int],
+    top_k: int = 6
+) -> Tuple[Dict[int, Dict[str, Any]], List[str]]:
+    """
+    Build short labels for clusters from TF-IDF top terms.
+    Accepts docs + labels (no external payload required).
+    """
+    n = len(docs)
+    if n == 0:
+        return {}, []
+
+    labels = np.asarray(labels, dtype=int)
+    texts = [(d.get("text") or "") for d in docs]
+
+    vec = TfidfVectorizer(
+        lowercase=True,
+        stop_words="english",
+        ngram_range=(1, 2),
+        max_features=20000,
+        token_pattern=r"(?u)\b[a-zA-Z][a-zA-Z\-]{2,}\b",
+    )
+    # If all texts are empty, avoid ValueError from vectorizer
+    if not any(t.strip() for t in texts):
+        per_doc = ["misc"] * n
+        return {}, per_doc
+
+    X = vec.fit_transform(texts)
+    vocab = np.asarray(vec.get_feature_names_out())
+
+    clusters: Dict[int, Dict[str, Any]] = {}
+
+    for c in np.unique(labels):
+        idx = np.where(labels == c)[0]
+        if idx.size == 0:
+            continue
+        # centroid over sparse rows; mean() yields 1 x F matrix
+        centroid = X[idx].mean(axis=0)
+        arr = np.asarray(centroid).ravel()
+        top_idx = arr.argsort()[-top_k:][::-1]
+        terms = vocab[top_idx].tolist()
+        title = ", ".join(terms[:3])
+        clusters[int(c)] = {
+            "label": title,
+            "top_terms": terms,
+            "size": int(idx.size),
+            "example_titles": [docs[i].get("title") for i in idx[:3]],
+        }
+
+    per_doc = [
+        clusters[int(labels[i])]["label"] if int(labels[i]) in clusters else "misc"
+        for i in range(n)
+    ]
+    return clusters, per_doc

--- a/miner/utils.py
+++ b/miner/utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+import re
+import unicodedata
+from typing import Optional, Iterable, Any
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+def html_to_text(html: Optional[str]) -> str:
+    if not html:
+        return ""
+    txt = _HTML_TAG_RE.sub(" ", html)
+    return _WS_RE.sub(" ", txt).strip()
+
+def uniq(seq: Iterable[Any]) -> list:
+    seen = set()
+    out = []
+    for x in seq:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+def slug(s: str, maxlen: int = 48) -> str:
+    s = (s or "").strip()
+    s = re.sub(r"[^A-Za-z0-9]+", "-", s).strip("-")
+    if len(s) > maxlen:
+        s = s[:maxlen].rstrip("-")
+    return s.lower() or "item"
+
+def normalize_title(s: str) -> str:
+    s = (s or "").strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    s = re.sub(r"[^\w\s\-:]+", "", s)
+    return s
+
+def safe_json(obj, path: Path):
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), "utf-8")
+
+def slugify(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", s).strip("-").lower()
+    return s or "item"

--- a/miner/vis.py
+++ b/miner/vis.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+
+_HTML = """<!doctype html>
+<meta charset="utf-8"/>
+<title>Paperclip Graph — Themes (Dynamic)</title>
+<style>
+  :root {
+    --bar-h: 62px;
+    --panel-w: 340px;
+    --gap: 10px;
+    --bg: #ffffff;
+    --ink: #111;
+    --muted: #666;
+    --line: #e6e6e6;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; height:100%; background:var(--bg); color:var(--ink); font: 13px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  #top {
+    height: var(--bar-h);
+    display:flex; align-items:center; gap:10px; padding:8px 12px; border-bottom:1px solid var(--line);
+    position:relative;
+  }
+  .badge { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; border:1px solid #cfcfcf; border-radius:999px; background:#fafafa; font-size:12px; }
+  #q { width: 340px; padding:8px 10px; border:1px solid var(--line); border-radius:8px; outline:none; }
+  #wrap { position:relative; height: calc(100vh - var(--bar-h)); width:100vw; overflow:hidden; }
+  #leftpanel {
+    position:absolute; top:10px; left:10px; width: var(--panel-w);
+    max-height: calc(100% - 20px); overflow:auto; padding:10px; background:#fff;
+    border:1px solid var(--line); border-radius:10px; box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  }
+  .section { margin-bottom:14px; }
+  .section h3 { margin:0 0 8px 0; font-size:12px; font-weight:700; letter-spacing: .02em; color:#222; text-transform:uppercase; }
+  .row { display:flex; align-items:center; gap:8px; padding:6px 4px; border-radius:6px; cursor:pointer; }
+  .row:hover { background:#f6f6f6; }
+  .row.disabled { opacity:.35 }
+  .swatch { width:14px; height:14px; border-radius:3px; border:1px solid rgba(0,0,0,0.15); flex:0 0 auto; }
+  .label { font-size:13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .pct { margin-left:auto; font-variant-numeric: tabular-nums; color:#444; font-size:12px; }
+  .slider { width:100%; }
+  .control { display:flex; align-items:center; gap:8px; margin:6px 0; }
+  .control label { width:130px; color:#333; font-size:12px; }
+  .muted { color: var(--muted); }
+  #canvas { position:absolute; left:0; top:0; width:100%; height:100%; display:block; }
+  #tip {
+    position:absolute; display:none; padding:6px 8px; font-size:12px; background:#fff;
+    border:1px solid #ddd; border-radius:6px; box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+    pointer-events:none; max-width:320px;
+  }
+  #minimap {
+    position:absolute; right:10px; bottom:10px; width: 200px; height:140px; background:#fff;
+    border:1px solid var(--line); border-radius:8px; box-shadow: 0 6px 18px rgba(0,0,0,0.06);
+  }
+  #buttons { display:flex; gap:6px; flex-wrap:wrap; }
+  button {
+    appearance:none; border:1px solid #ccc; background:#fff; padding:6px 8px; border-radius:8px; cursor:pointer; font-size:12px;
+  }
+  button:active { transform: translateY(1px); }
+  .pill { padding:2px 6px; border-radius:999px; border:1px solid #bbb; }
+</style>
+
+<div id="top">
+  <span class="badge" id="count">0 nodes</span>
+  <span class="badge" id="edges">0 edges</span>
+  <input id="q" type="search" placeholder="Search title / citekey / DOI / URL (Regex ok: /pattern/)" />
+  <span class="badge"><input id="anim" type="checkbox" checked /> <label for="anim">Animate</label></span>
+  <span class="badge"><input id="pinDrag" type="checkbox" checked /> <label for="pinDrag">Pin on drag</label></span>
+  <span class="badge"><input id="fadeMode" type="checkbox" checked /> <label for="fadeMode">Fade hidden</label></span>
+  <span class="badge">Depth <input id="depth" type="range" min="0" max="3" step="1" value="0" style="vertical-align:middle"> <span id="depthVal" class="pill">0</span></span>
+</div>
+
+<div id="wrap">
+  <div id="leftpanel">
+    <div class="section" id="legendSec">
+      <h3>Themes</h3>
+      <div id="legend"></div>
+      <div class="muted" style="margin-top:6px;">Click to toggle • Shift+Click to isolate</div>
+    </div>
+
+    <div class="section" id="physicsSec">
+      <h3>Physics</h3>
+      <div class="control"><label>Repulsion</label><input id="repel" class="slider" type="range" min="100" max="2500" value="1200"><span id="repelVal" class="muted">1200</span></div>
+      <div class="control"><label>Spring</label><input id="spring" class="slider" type="range" min="1" max="50" value="10"><span id="springVal" class="muted">0.010</span></div>
+      <div class="control"><label>Damping</label><input id="damp" class="slider" type="range" min="70" max="95" value="85"><span id="dampVal" class="muted">0.85</span></div>
+      <div class="control"><label>Center pull</label><input id="center" class="slider" type="range" min="0" max="30" value="5"><span id="centerVal" class="muted">0.005</span></div>
+      <div id="buttons" style="margin-top:8px;">
+        <button id="resetLayout">Reset layout</button>
+        <button id="centerView">Center view</button>
+        <button id="savePos">Save</button>
+        <button id="loadPos">Load</button>
+        <button id="clearPos">Clear</button>
+        <button id="exportPng">Export PNG</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h3>View</h3>
+      <div class="control"><label><input id="labels" type="checkbox" checked> Labels on hover/selection</label></div>
+    </div>
+  </div>
+
+  <canvas id="canvas"></canvas>
+  <canvas id="minimap"></canvas>
+  <div id="tip"></div>
+</div>
+
+<script>
+// ====== Inline data (no fetch) ======
+const G = __GRAPH_JSON__;
+const THEMES = __THEMES_JSON__ || {};
+const nodes = G.nodes || [];
+const edges = G.edges || [];
+const N = nodes.length;
+
+// ====== Counters ======
+document.getElementById('count').textContent = N + ' nodes';
+document.getElementById('edges').textContent = edges.length + ' edges';
+
+// ====== Utilities ======
+function colorForCluster(c){
+  const h = ((parseInt(c,10)+1) * 137.508) % 360;
+  return `hsl(${h},70%,50%)`;
+}
+function hsla(c,a){ return c.replace('hsl','hsla').replace(')',`,`+a+`)`); }
+function clamp(v, lo, hi){ return Math.max(lo, Math.min(hi, v)); }
+function lerp(a,b,t){ return a+(b-a)*t; }
+function fnv1a(str){ let h=0x811c9dc5; for(let i=0;i<str.length;i++){h^=str.charCodeAt(i);h=(h>>>0)*0x01000193} return (h>>>0).toString(16); }
+
+// ====== Theme metadata & legend ======
+const clusterIds = Array.from(new Set(nodes.map(n => n.clusterId))).sort((a,b)=>a-b);
+const themeMeta = {};
+const totals = { all: N };
+for(const cid of clusterIds){
+  const meta = THEMES?.[cid] || THEMES?.[String(cid)] || {};
+  const size = (meta.size != null) ? meta.size : nodes.filter(n => n.clusterId===cid).length;
+  themeMeta[cid] = {
+    label: meta.label || `Theme ${cid}`,
+    top_terms: meta.top_terms || [],
+    size,
+    color: colorForCluster(cid)
+  };
+}
+const legend = document.getElementById('legend');
+const sortedC = clusterIds.slice().sort((a,b)=>(themeMeta[b].size - themeMeta[a].size));
+let activeThemes = new Set(sortedC);
+function rebuildLegend(){
+  legend.innerHTML = '';
+  for(const cid of sortedC){
+    const meta = themeMeta[cid];
+    const row = document.createElement('div');
+    row.className = 'row';
+    row.dataset.cid = String(cid);
+    row.innerHTML = `
+      <div class="swatch" style="background:${meta.color}"></div>
+      <div class="label" title="${meta.top_terms.slice(0,8).join(', ')}">${meta.label}</div>
+      <div class="pct">${meta.size} • ${((meta.size/N)*100).toFixed(1)}%</div>
+    `;
+    const setState = ()=>{ row.classList.toggle('disabled', !activeThemes.has(cid)); };
+    setState();
+    row.addEventListener('click', (e)=>{
+      if(e.shiftKey){ activeThemes = new Set([cid]); }
+      else { activeThemes.has(cid) ? activeThemes.delete(cid) : activeThemes.add(cid); }
+      for(const r of legend.querySelectorAll('.row')) r.classList.toggle('disabled', !activeThemes.has(parseInt(r.dataset.cid)));
+      computeVisibility(); // recompute visible sets
+    });
+    legend.appendChild(row);
+  }
+}
+rebuildLegend();
+
+// ====== Build adjacency ======
+const adj = Array.from({length:N}, ()=>[]);
+edges.forEach(e => { adj[e.source].push(e.target); adj[e.target].push(e.source); });
+
+// ====== Positions / physics ======
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d', { alpha: false });
+const dpr = window.devicePixelRatio || 1;
+function resize(){
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width*dpr; canvas.height = rect.height*dpr;
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+}
+function fitCanvas(){ const wrap = document.getElementById('wrap'); canvas.style.width='100%'; canvas.style.height='100%'; resize(); }
+window.addEventListener('resize', resize);
+
+let pos = Array.from({length:N}, _=>({x:Math.random()*800-400, y:Math.random()*600-300}));
+let vel = Array.from({length:N}, _=>({x:0,y:0}));
+let pinned = new Array(N).fill(false);
+
+// Layout persistence
+const datasetKey = fnv1a(JSON.stringify(nodes.map(n=>n.docId||n.title||n.id)) + '|' + N);
+const LS_KEY = 'pc_graph_pos_' + datasetKey;
+function savePositions(){ localStorage.setItem(LS_KEY, JSON.stringify({pos, pinned})); }
+function loadPositions(){
+  try{
+    const s = localStorage.getItem(LS_KEY);
+    if(!s) return false;
+    const obj = JSON.parse(s);
+    if(!obj || !Array.isArray(obj.pos) || obj.pos.length!==N) return false;
+    pos = obj.pos; pinned = Array.isArray(obj.pinned) && obj.pinned.length===N ? obj.pinned : new Array(N).fill(false);
+    return true;
+  }catch(e){ return false; }
+}
+
+// Physics params (UI-backed)
+const ui = {
+  anim: document.getElementById('anim'),
+  pinDrag: document.getElementById('pinDrag'),
+  fadeMode: document.getElementById('fadeMode'),
+  labels: document.getElementById('labels'),
+  repel: document.getElementById('repel'),
+  spring: document.getElementById('spring'),
+  damp: document.getElementById('damp'),
+  center: document.getElementById('center'),
+  depth: document.getElementById('depth'),
+  depthVal: document.getElementById('depthVal'),
+  repelVal: document.getElementById('repelVal'),
+  springVal: document.getElementById('springVal'),
+  dampVal: document.getElementById('dampVal'),
+  centerVal: document.getElementById('centerVal'),
+  q: document.getElementById('q'),
+  exportPng: document.getElementById('exportPng'),
+  resetLayout: document.getElementById('resetLayout'),
+  centerView: document.getElementById('centerView'),
+  savePos: document.getElementById('savePos'),
+  loadPos: document.getElementById('loadPos'),
+  clearPos: document.getElementById('clearPos'),
+};
+function syncLabels(){
+  ui.repelVal.textContent = parseInt(ui.repel.value);
+  ui.springVal.textContent = (parseInt(ui.spring.value)/1000).toFixed(3);
+  ui.dampVal.textContent = (parseInt(ui.damp.value)/100).toFixed(2);
+  ui.centerVal.textContent = (parseInt(ui.center.value)/1000).toFixed(3);
+  ui.depthVal.textContent = ui.depth.value;
+}
+['input','change'].forEach(ev=>{
+  ui.repel.addEventListener(ev, syncLabels);
+  ui.spring.addEventListener(ev, syncLabels);
+  ui.damp.addEventListener(ev, syncLabels);
+  ui.center.addEventListener(ev, syncLabels);
+  ui.depth.addEventListener(ev, ()=>{ syncLabels(); computeVisibility(); });
+});
+syncLabels();
+
+// Pan/zoom
+let scale = 1, dx = 0, dy = 0;
+function worldToScreen(p){ return {x: p.x*scale + dx, y: p.y*scale + dy}; }
+function screenToWorld(x,y){ return {x: (x - dx)/scale, y: (y - dy)/scale}; }
+
+// Drag/select
+let dragging=false, dragIdx=-1, lastX=0, lastY=0;
+let hover=-1;
+let selected = new Set();
+canvas.addEventListener('mousedown', e=>{
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX-rect.left), my = (e.clientY-rect.top);
+  const w = screenToWorld(mx, my);
+  // pick nearest
+  let best=-1, bd=1e9;
+  for(let i=0;i<N;i++){
+    if(!visible[i]) continue;
+    const dxp = pos[i].x - w.x, dyp = pos[i].y - w.y;
+    const d2 = dxp*dxp + dyp*dyp;
+    if(d2<bd){ bd=d2; best=i; }
+  }
+  if(best>=0 && Math.sqrt(bd) < 16){ dragging=true; dragIdx=best; lastX=mx; lastY=my; if(!e.ctrlKey && !e.metaKey) selected.clear(); selected.add(best); }
+  else { dragging=true; dragIdx=-1; lastX=mx; lastY=my; if(!e.ctrlKey && !e.metaKey) selected.clear(); }
+});
+canvas.addEventListener('mousemove', e=>{
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX-rect.left), my = (e.clientY-rect.top);
+  const w = screenToWorld(mx, my);
+
+  // Hover tip
+  let best=-1, bd=1e9;
+  for(let i=0;i<N;i++){
+    if(!visible[i]) continue;
+    const dxp = pos[i].x - w.x, dyp = pos[i].y - w.y;
+    const d2 = dxp*dxp + dyp*dyp;
+    if(d2<bd){ bd=d2; best=i; }
+  }
+  if(best>=0 && Math.sqrt(bd) < 14){ hover=best; showTip(e.clientX, e.clientY, best); }
+  else { hover=-1; hideTip(); }
+
+  if(!dragging) return;
+  if(dragIdx>=0){
+    const dWorld = screenToWorld(mx,my);
+    pos[dragIdx].x = dWorld.x;
+    pos[dragIdx].y = dWorld.y;
+    if(ui.pinDrag.checked) pinned[dragIdx] = true;
+  } else {
+    dx += (mx - lastX); dy += (my - lastY);
+  }
+  lastX = mx; lastY = my;
+});
+['mouseup','mouseleave'].forEach(ev=>canvas.addEventListener(ev, ()=>{ dragging=false; dragIdx=-1; }));
+canvas.addEventListener('dblclick', ()=>{
+  // center on selection
+  if(!selected.size) return;
+  const c = centroid([...selected]);
+  centerOn(c.x, c.y);
+});
+
+canvas.addEventListener('wheel', e=>{
+  e.preventDefault();
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX-rect.left), my = (e.clientY-rect.top);
+  const before = screenToWorld(mx,my);
+  const s = Math.exp(-e.deltaY*0.001);
+  scale = clamp(scale*s, 0.2, 6);
+  const after = screenToWorld(mx,my);
+  dx += (mx - (after.x*scale)) - (mx - (before.x*scale));
+  dy += (my - (after.y*scale)) - (my - (before.y*scale));
+}, {passive:false});
+
+// Tooltip
+const tip = document.getElementById('tip');
+function showTip(cx, cy, i){
+  const n = nodes[i]; const cid = n.clusterId;
+  const meta = themeMeta[cid];
+  tip.innerHTML = `<b>${escapeHtml(n.title || n.citekey || n.docId || 'Untitled')}</b><br>
+    <span class="muted">${escapeHtml(meta.label)}</span><br>
+    <small>${escapeHtml((meta.top_terms||[]).slice(0,8).join(', '))}</small>`;
+  tip.style.left = (cx+12)+'px';
+  tip.style.top = (cy+8)+'px';
+  tip.style.display = 'block';
+}
+function hideTip(){ tip.style.display = 'none'; }
+function escapeHtml(s){ return String(s||'').replace(/[&<>"]/g, m=>({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;'}[m])); }
+
+// ====== Filters: search + themes + local depth ======
+let visible = new Array(N).fill(true);
+let matchQ = new Array(N).fill(true);
+let depthMask = new Array(N).fill(true);
+
+function computeVisibility(){
+  // Search filter
+  const raw = (ui.q.value || '').trim();
+  let asRegex = null;
+  if(raw.startsWith('/') && raw.endsWith('/') && raw.length>2){
+    try{ asRegex = new RegExp(raw.slice(1,-1), 'i'); } catch(e){ asRegex = null; }
+  }
+  for(let i=0;i<N;i++){
+    const hay = (nodes[i].title||'')+' '+(nodes[i].citekey||'')+' '+(nodes[i].doi||'')+' '+(nodes[i].url||'');
+    matchQ[i] = asRegex ? asRegex.test(hay) : hay.toLowerCase().includes(raw.toLowerCase());
+  }
+
+  // Local depth (BFS from selected)
+  const maxDepth = parseInt(ui.depth.value);
+  if(maxDepth>0 && selected.size){
+    depthMask.fill(false);
+    const q = [...selected].map(i=>({i, d:0}));
+    for(const s of q) depthMask[s.i] = true;
+    let head=0;
+    while(head<q.length){
+      const {i,d} = q[head++]; if(d>=maxDepth) continue;
+      for(const nb of adj[i]){
+        if(!depthMask[nb]){ depthMask[nb]=true; q.push({i:nb, d:d+1}); }
+      }
+    }
+  } else {
+    depthMask.fill(true);
+  }
+
+  // Theme filter
+  for(let i=0;i<N;i++){
+    const onTheme = activeThemes.has(nodes[i].clusterId);
+    visible[i] = onTheme && matchQ[i] && depthMask[i];
+  }
+
+  // Repaint
+  needRedraw = true;
+}
+
+ui.q.addEventListener('input', computeVisibility);
+
+// ====== Physics engine ======
+let needRedraw = true;
+function stepPhysics(dt=1){
+  const K = parseInt(ui.spring.value)/1000;
+  const REP = parseInt(ui.repel.value);
+  const DAMP = parseInt(ui.damp.value)/100;
+  const CTR = parseInt(ui.center.value)/1000;
+
+  // Simple center pull
+  for(let i=0;i<N;i++){
+    if(pinned[i]) continue;
+    vel[i].x += -pos[i].x * CTR;
+    vel[i].y += -pos[i].y * CTR;
+  }
+
+  // Springs along edges
+  for(const e of edges){
+    const i=e.source, j=e.target;
+    const dx = pos[j].x - pos[i].x, dy = pos[j].y - pos[i].y;
+    vel[i].x += K*dx; vel[i].y += K*dy;
+    vel[j].x -= K*dx; vel[j].y -= K*dy;
+  }
+
+  // Repulsion (O(n^2); throttle for large N)
+  const stride = N>800 ? 2 : 1;
+  for(let i=0;i<N;i+=stride){
+    for(let j=i+1;j<N;j+=stride){
+      const dx = pos[i].x - pos[j].x, dy = pos[i].y - pos[j].y;
+      const d2 = Math.max(49, dx*dx + dy*dy);
+      const f = REP / d2; const invd = 1/Math.sqrt(d2);
+      const fx = f*dx*invd, fy = f*dy*invd;
+      if(!pinned[i]){ vel[i].x += fx; vel[i].y += fy; }
+      if(!pinned[j]){ vel[j].x -= fx; vel[j].y -= fy; }
+    }
+  }
+
+  // Integrate + damping
+  for(let i=0;i<N;i++){
+    if(pinned[i]) continue;
+    pos[i].x += vel[i].x*dt; pos[i].y += vel[i].y*dt;
+    vel[i].x *= DAMP; vel[i].y *= DAMP;
+  }
+}
+
+function centroid(list){
+  if(!list.length) return {x:0,y:0};
+  let x=0,y=0; for(const i of list){ x+=pos[i].x; y+=pos[i].y; } return {x:x/list.length, y:y/list.length};
+}
+function centerOn(wx, wy){
+  const rect = canvas.getBoundingClientRect();
+  dx = rect.width/2 - wx*scale;
+  dy = rect.height/2 - wy*scale;
+  needRedraw = true;
+}
+
+// ====== Render ======
+function draw(){
+    ctx.fillStyle = "#fff";  
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Halos per active theme (centroid + spread over visible nodes of that theme)
+  for(const cid of sortedC){
+    const ids = [];
+    for(let i=0;i<N;i++) if(visible[i] && nodes[i].clusterId===cid) ids.push(i);
+    if(!ids.length) continue;
+    const c = centroid(ids);
+    let r2=0; for(const i of ids){ const dx=pos[i].x-c.x, dy=pos[i].y-c.y; r2 += dx*dx+dy*dy; }
+    const r = Math.sqrt(r2/ids.length)*1.35 + 22;
+    const cs = worldToScreen(c);
+    ctx.beginPath(); ctx.arc(cs.x, cs.y, r*scale, 0, Math.PI*2);
+    ctx.fillStyle = hsla(themeMeta[cid].color, 0.08); ctx.fill();
+    ctx.lineWidth = 1; ctx.strokeStyle = hsla(themeMeta[cid].color, 0.35); ctx.stroke();
+
+    // theme label
+    ctx.font = '600 14px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#000'; ctx.globalAlpha = 0.85;
+    const label = themeMeta[cid].label;
+    const tw = ctx.measureText(label).width;
+    ctx.fillText(label, cs.x - tw/2, cs.y - r*scale - 6);
+    ctx.globalAlpha = 1;
+  }
+
+  // Edges
+  ctx.lineWidth = 1;
+  for(const e of edges){
+    const i=e.source, j=e.target;
+    const on = visible[i] && visible[j];
+    const s = worldToScreen(pos[i]), t = worldToScreen(pos[j]);
+    ctx.strokeStyle = on ? 'rgba(0,0,0,0.16)' : (ui.fadeMode.checked ? 'rgba(0,0,0,0.03)' : 'rgba(0,0,0,0)');
+    ctx.beginPath(); ctx.moveTo(s.x, s.y); ctx.lineTo(t.x, t.y); ctx.stroke();
+  }
+
+  // Nodes
+  for(let i=0;i<N;i++){
+    const on = visible[i];
+    const n = nodes[i];
+    const c = themeMeta[n.clusterId]?.color || '#444';
+    const p = worldToScreen(pos[i]);
+    const deg = (n.degree||0);
+    const r = 3.5 + Math.sqrt(Math.max(0,deg))*0.6 + (selected.has(i)?2:0);
+    ctx.beginPath(); ctx.arc(p.x, p.y, r, 0, Math.PI*2);
+    ctx.fillStyle = on ? c : (ui.fadeMode.checked ? 'rgba(0,0,0,0.2)' : 'rgba(0,0,0,0)');
+    ctx.fill();
+    if(selected.has(i)){
+      ctx.lineWidth = 2; ctx.strokeStyle = '#000'; ctx.stroke();
+    }
+  }
+
+  // Labels (hover/selection)
+  if(ui.labels.checked){
+    ctx.font = '12px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#111';
+    const toShow = new Set(selected);
+    if(hover>=0) toShow.add(hover);
+    for(const i of toShow){
+      if(!visible[i]) continue;
+      const p = worldToScreen(pos[i]);
+      const text = nodes[i].title || nodes[i].citekey || nodes[i].docId || 'Untitled';
+      ctx.fillText(text, p.x+8, p.y-8);
+    }
+  }
+
+  drawMinimap();
+}
+
+const mini = document.getElementById('minimap');
+const mctx = mini.getContext('2d');
+function drawMinimap(){
+  const rect = mini.getBoundingClientRect();
+  mini.width = rect.width*dpr; mini.height = rect.height*dpr; mctx.setTransform(dpr,0,0,dpr,0,0);
+  mctx.clearRect(0,0,mini.width,mini.height);
+  // compute world bounds
+  let minx=1e9,miny=1e9,maxx=-1e9,maxy=-1e9;
+  for(let i=0;i<N;i++){ minx=Math.min(minx,pos[i].x); miny=Math.min(miny,pos[i].y); maxx=Math.max(maxx,pos[i].x); maxy=Math.max(maxy,pos[i].y); }
+  const w = maxx-minx, h = maxy-miny;
+  const sx = rect.width/(w||1), sy = rect.height/(h||1);
+  const s = Math.min(sx, sy)*0.9;
+  const ox = (rect.width - w*s)/2 - minx*s, oy = (rect.height - h*s)/2 - miny*s;
+
+  // edges
+  mctx.strokeStyle = 'rgba(0,0,0,0.08)'; mctx.lineWidth=1;
+  for(const e of edges){
+    const i=e.source, j=e.target;
+    if(!(visible[i] && visible[j])) continue;
+    mctx.beginPath();
+    mctx.moveTo(pos[i].x*s+ox, pos[i].y*s+oy);
+    mctx.lineTo(pos[j].x*s+ox, pos[j].y*s+oy);
+    mctx.stroke();
+  }
+  // nodes
+  for(let i=0;i<N;i++){
+    if(!visible[i]) continue;
+    mctx.beginPath();
+    mctx.arc(pos[i].x*s+ox, pos[i].y*s+oy, 1.8, 0, Math.PI*2);
+    mctx.fillStyle = themeMeta[nodes[i].clusterId]?.color || '#444';
+    mctx.fill();
+  }
+  // viewport box
+  // map the four corners of screen->world rect back into minimap space
+  const rectCanvas = canvas.getBoundingClientRect();
+  const tl = screenToWorld(0,0), br = screenToWorld(rectCanvas.width, rectCanvas.height);
+  mctx.strokeStyle = 'rgba(0,0,0,0.6)';
+  mctx.strokeRect(tl.x*s+ox, tl.y*s+oy, (br.x-tl.x)*s, (br.y-tl.y)*s);
+}
+mini.addEventListener('click', (e)=>{
+  const r = mini.getBoundingClientRect();
+  const x = e.clientX - r.left, y = e.clientY - r.top;
+  // compute same transform as drawMinimap()
+  let minx=1e9,miny=1e9,maxx=-1e9,maxy=-1e9;
+  for(let i=0;i<N;i++){ minx=Math.min(minx,pos[i].x); miny=Math.min(miny,pos[i].y); maxx=Math.max(maxx,pos[i].x); maxy=Math.max(maxy,pos[i].y); }
+  const w = maxx-minx, h = maxy-miny;
+  const sx = r.width/(w||1), sy = r.height/(h||1), s = Math.min(sx,sy)*0.9;
+  const ox = (r.width - w*s)/2 - minx*s, oy = (r.height - h*s)/2 - miny*s;
+
+  // convert minimap click to world coords and center there
+  const wx = (x - ox)/s, wy = (y - oy)/s;
+  centerOn(wx, wy);
+});
+
+// ====== Controls ======
+ui.resetLayout.addEventListener('click', ()=>{
+  pos = Array.from({length:N}, _=>({x:Math.random()*800-400, y:Math.random()*600-300}));
+  vel = Array.from({length:N}, _=>({x:0,y:0}));
+  pinned = new Array(N).fill(false);
+  centerOn(0,0); needRedraw = true;
+});
+ui.centerView.addEventListener('click', ()=>{
+  if(selected.size){ const c = centroid([...selected]); centerOn(c.x, c.y); }
+  else centerOn(0,0);
+});
+ui.savePos.addEventListener('click', savePositions);
+ui.loadPos.addEventListener('click', ()=>{ if(loadPositions()) needRedraw=true; });
+ui.clearPos.addEventListener('click', ()=>{ localStorage.removeItem(LS_KEY); });
+ui.exportPng.addEventListener('click', ()=>{
+  const tmp = document.createElement('canvas');
+  const r = canvas.getBoundingClientRect();
+  tmp.width = r.width*dpr; tmp.height = r.height*dpr;
+  const tctx = tmp.getContext('2d'); tctx.setTransform(dpr,0,0,dpr,0,0);
+  // white background
+  tctx.fillStyle = '#fff'; tctx.fillRect(0,0,tmp.width,tmp.height);
+  // draw current frame
+  tctx.drawImage(canvas, 0,0);
+  const url = tmp.toDataURL('image/png');
+  const a = document.createElement('a'); a.href = url; a.download = 'graph.png'; a.click();
+});
+
+// ====== Animation loop ======
+function frame(){
+  if(ui.anim.checked || dragging) {
+    stepPhysics(1);
+    needRedraw = true;
+  }
+  if(needRedraw){ draw(); needRedraw=false; }
+  requestAnimationFrame(frame);
+}
+
+// ====== Init ======
+function init(){
+  fitCanvas();
+  // Try to load saved positions
+  if(!loadPositions()){
+    // run a few warm-up iterations for nicer start
+    for(let i=0;i<260;i++) stepPhysics(1);
+  }
+  computeVisibility();
+  centerOn(0,0);
+  frame();
+}
+init();
+</script>
+"""
+
+def _escape_for_script(s: str) -> str:
+    # Avoid closing the <script> tag from inside JSON (e.g., in titles)
+    return s.replace("</", "<\\/").replace("<!--", "<\\!--")
+
+def write_graph_html(graph: dict, themes: dict, out_html: Path):
+    """
+    Embed both the graph and theme metadata directly into the HTML so it works over file://.
+    """
+    g = json.dumps(graph, ensure_ascii=False)
+    t = json.dumps({int(k): v for k, v in (themes or {}).items()}, ensure_ascii=False)
+    html = _HTML.replace("__GRAPH_JSON__", _escape_for_script(g)).replace("__THEMES_JSON__", _escape_for_script(t))
+    out_html.write_text(html, encoding="utf-8")

--- a/paperclip/parsers/sites/sciencedirect.py
+++ b/paperclip/parsers/sites/sciencedirect.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
+import html
 import re
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from urllib.parse import parse_qsl, urlparse
 
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, NavigableString, Tag
 
 from ..base import BaseParser, ReferenceObj, DOI_RE
 
 class ScienceDirectParser(BaseParser):
     NAME = "ScienceDirect"
     DOMAINS = ("sciencedirect.com", "elsevier.com")
+    SECTION_ID_RE = re.compile(r"^cesec", re.I)
 
     @classmethod
     def detect(cls, url: str, soup: BeautifulSoup) -> bool:
@@ -376,3 +378,127 @@ class ScienceDirectParser(BaseParser):
             if heading_text.startswith("graphical summary"):
                 return True
         return False
+
+    @classmethod
+    def _build_content_sections(cls, soup: BeautifulSoup) -> dict[str, Any]:
+        content = super()._build_content_sections(soup)
+        body_sections = cls._extract_body_sections(soup)
+        if body_sections:
+            content["body"] = body_sections
+        return content
+
+    @classmethod
+    def _extract_body_sections(cls, soup: BeautifulSoup) -> list[dict[str, Any]]:
+        body_root = cls._locate_body_root(soup)
+        sections: list[Tag] = []
+        if body_root:
+            for child in body_root.find_all("section", recursive=False):
+                if cls._is_sciencedirect_section(child):
+                    sections.append(child)
+        if not sections:
+            for candidate in soup.select("section[id]"):
+                if not cls._is_sciencedirect_section(candidate):
+                    continue
+                if any(
+                    isinstance(parent, Tag)
+                    and parent is not candidate
+                    and cls._is_sciencedirect_section(parent)
+                    for parent in candidate.parents
+                ):
+                    continue
+                sections.append(candidate)
+        results: list[dict[str, Any]] = []
+        for idx, section in enumerate(sections, start=1):
+            built = cls._build_body_section(section, fallback_title=f"Section {idx}")
+            if built:
+                results.append(built)
+        return results
+
+    @classmethod
+    def _locate_body_root(cls, soup: BeautifulSoup) -> Optional[Tag]:
+        selectors = [
+            "section.Sections",
+            "section.article-body",
+            "section[id^='body']",
+            "div.article-body",
+        ]
+        for selector in selectors:
+            node = soup.select_one(selector)
+            if isinstance(node, Tag):
+                return node
+        return None
+
+    @classmethod
+    def _build_body_section(cls, node: Tag, fallback_title: Optional[str]) -> Optional[dict[str, Any]]:
+        heading = cls._leading_heading(node)
+        title = cls._text(heading) if heading else None
+        title = title or fallback_title or (node.get("id") or "").strip() or None
+
+        html_fragments: list[str] = []
+        children: list[dict[str, Any]] = []
+        subsection_index = 1
+
+        for child in node.children:
+            if isinstance(child, NavigableString):
+                fragment = cls._normalise_body_html(child)
+                if fragment:
+                    html_fragments.append(fragment)
+                continue
+            if not isinstance(child, Tag):
+                continue
+            if heading and child is heading:
+                continue
+            if cls._is_sciencedirect_section(child):
+                child_fallback = None
+                if title or fallback_title:
+                    basis = title or fallback_title or "Section"
+                    child_fallback = f"{basis} {subsection_index}"
+                else:
+                    child_fallback = f"Section {subsection_index}"
+                subsection_index += 1
+                built_child = cls._build_body_section(child, child_fallback)
+                if built_child:
+                    children.append(built_child)
+                continue
+            fragment = cls._normalise_body_html(child)
+            if fragment:
+                html_fragments.append(fragment)
+
+        html_content = "".join(html_fragments).strip()
+        if not html_content and not children:
+            return None
+
+        data: dict[str, Any] = {
+            "title": title or fallback_title or "",
+            "html": html_content,
+        }
+        if children:
+            data["children"] = children
+        return data
+
+    @classmethod
+    def _normalise_body_html(cls, node: Tag | NavigableString) -> str:
+        if isinstance(node, NavigableString):
+            text = str(node).strip()
+            if not text:
+                return ""
+            return f"<p>{html.escape(text)}</p>"
+        if not isinstance(node, Tag):
+            return ""
+        if node.name in {"script", "style"}:
+            return ""
+        if cls._is_sciencedirect_section(node):
+            return ""
+        if node.name == "div":
+            inner = node.decode_contents().strip()
+            if not inner:
+                return ""
+            return f"<p>{inner}</p>"
+        return node.decode().strip()
+
+    @classmethod
+    def _is_sciencedirect_section(cls, node: Tag) -> bool:
+        if node.name != "section":
+            return False
+        ident = node.get("id") or ""
+        return bool(ident and cls.SECTION_ID_RE.search(ident))

--- a/paperclip/parsers/sites/sciencedirect.py
+++ b/paperclip/parsers/sites/sciencedirect.py
@@ -465,6 +465,8 @@ class ScienceDirectParser(BaseParser):
                 html_fragments.append(fragment)
 
         html_content = "".join(html_fragments).strip()
+        if html_content:
+            html_content = cls._annotate_body_html(html_content)
         if not html_content and not children:
             return None
 
@@ -482,7 +484,8 @@ class ScienceDirectParser(BaseParser):
             text = str(node).strip()
             if not text:
                 return ""
-            return f"<p>{html.escape(text)}</p>"
+            fragment = f"<p>{html.escape(text)}</p>"
+            return cls._annotate_body_html(fragment)
         if not isinstance(node, Tag):
             return ""
         if node.name in {"script", "style"}:
@@ -493,8 +496,132 @@ class ScienceDirectParser(BaseParser):
             inner = node.decode_contents().strip()
             if not inner:
                 return ""
-            return f"<p>{inner}</p>"
+            fragment = f"<p>{inner}</p>"
+            return cls._annotate_body_html(fragment)
+        if node.name == "p":
+            return cls._annotate_body_html(node.decode().strip())
         return node.decode().strip()
+
+    @classmethod
+    def _annotate_body_html(cls, html_fragment: str) -> str:
+        if not html_fragment:
+            return html_fragment
+        soup = BeautifulSoup(f"<wrapper>{html_fragment}</wrapper>", "html.parser")
+        modified = False
+        for block in soup.wrapper.find_all(["p", "li"], recursive=True):
+            updated = cls._wrap_sentence_citations(block.decode_contents())
+            if updated != block.decode_contents():
+                block.clear()
+                replacement = BeautifulSoup(f"<wrapper>{updated}</wrapper>", "html.parser")
+                for child in list(replacement.wrapper.contents):
+                    block.append(child)
+                modified = True
+        if not modified:
+            return html_fragment
+        return soup.wrapper.decode_contents()
+
+    @classmethod
+    def _wrap_sentence_citations(cls, html_fragment: str) -> str:
+        if not html_fragment:
+            return html_fragment
+
+        tag_pattern = re.compile(r"<[^>]+>")
+        tags: list[str] = []
+
+        def _store_tag(match: re.Match[str]) -> str:
+            tags.append(match.group(0))
+            return f"@@TAG{len(tags) - 1}@@"
+
+        tokenised = tag_pattern.sub(_store_tag, html_fragment)
+        sentences = cls._split_sentences(tokenised)
+        if not sentences:
+            return html_fragment
+
+        rebuilt: list[str] = []
+        for sentence in sentences:
+            refs = cls._extract_sentence_references(sentence, tags)
+            restored = cls._restore_tokens(sentence, tags)
+            if refs:
+                leading_ws = re.match(r"^\s*", restored)
+                trailing_ws = re.search(r"\s*$", restored)
+                leading = leading_ws.group(0) if leading_ws else ""
+                trailing = trailing_ws.group(0) if trailing_ws else ""
+                core = restored[len(leading): len(restored) - len(trailing) if trailing else len(restored)]
+                span = f'<span data-citation-refs="{" ".join(refs)}">{core}</span>'
+                rebuilt.append(f"{leading}{span}{trailing}")
+            else:
+                rebuilt.append(restored)
+        return "".join(rebuilt)
+
+    @staticmethod
+    def _restore_tokens(text: str, tags: list[str]) -> str:
+        if not text:
+            return text
+        return re.sub(r"@@TAG(\d+)@@", lambda m: tags[int(m.group(1))], text)
+
+    @classmethod
+    def _extract_sentence_references(cls, sentence: str, tags: list[str]) -> list[str]:
+        refs: list[str] = []
+        seen: set[str] = set()
+        for match in re.finditer(r"@@TAG(\d+)@@", sentence):
+            tag_index = int(match.group(1))
+            tag_text = tags[tag_index]
+            ref_id = cls._reference_id_from_tag(tag_text)
+            if not ref_id or ref_id in seen:
+                continue
+            seen.add(ref_id)
+            refs.append(ref_id)
+        return refs
+
+    @staticmethod
+    def _reference_id_from_tag(tag_text: str) -> Optional[str]:
+        if not tag_text.lower().startswith("<a"):
+            return None
+        href_match = re.search(r'href="#([^"#]+)"', tag_text, flags=re.I)
+        if href_match:
+            candidate = href_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        data_id_match = re.search(r'data-xocs-content-id="([^"#]+)"', tag_text, flags=re.I)
+        if data_id_match:
+            candidate = data_id_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        name_match = re.search(r'name="([^"#]+)"', tag_text, flags=re.I)
+        if name_match:
+            candidate = name_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        return None
+
+    @staticmethod
+    def _split_sentences(text: str) -> list[str]:
+        sentences: list[str] = []
+        start = 0
+        length = len(text)
+        i = 0
+        while i < length:
+            char = text[i]
+            if char in ".?!":
+                j = i + 1
+                while j < length and text[j] in ")\"]":
+                    j += 1
+                next_char = text[j] if j < length else ""
+                next_token = text[j:j + 6]
+                if j >= length or next_char.isspace() or next_token.startswith("@@TAG"):
+                    segment = text[start:j]
+                    if segment:
+                        sentences.append(segment)
+                    while j < length and text[j].isspace():
+                        sentences.append(text[j])
+                        j += 1
+                    start = j
+                    i = j
+                    continue
+            i += 1
+        if start < length:
+            sentences.append(text[start:])
+        return sentences
 
     @classmethod
     def _is_sciencedirect_section(cls, node: Tag) -> bool:

--- a/paperclip/parsers/sites/sciencedirect/__init__.py
+++ b/paperclip/parsers/sites/sciencedirect/__init__.py
@@ -1,0 +1,3 @@
+from .parser import ScienceDirectParser
+
+__all__ = ["ScienceDirectParser"]

--- a/paperclip/parsers/sites/sciencedirect/body.py
+++ b/paperclip/parsers/sites/sciencedirect/body.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import html
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+from .citations import SentenceCitationAnnotator
+
+
+@dataclass
+class BodyExtractor:
+    citation_annotator: SentenceCitationAnnotator
+    section_predicate: Callable[[Tag], bool]
+    heading_finder: Callable[[Tag], Optional[Tag]]
+
+    def extract(self, soup: BeautifulSoup) -> List[dict[str, Any]]:
+        body_root = self._locate_body_root(soup)
+        sections: List[Tag] = []
+        if body_root:
+            for child in body_root.find_all("section", recursive=False):
+                if self.section_predicate(child):
+                    sections.append(child)
+        if not sections:
+            for candidate in soup.select("section[id]"):
+                if not self.section_predicate(candidate):
+                    continue
+                if any(
+                    isinstance(parent, Tag)
+                    and parent is not candidate
+                    and self.section_predicate(parent)
+                    for parent in candidate.parents
+                ):
+                    continue
+                sections.append(candidate)
+
+        results: List[dict[str, Any]] = []
+        for idx, section in enumerate(sections, start=1):
+            built = self._build_body_section(section, fallback_title=f"Section {idx}")
+            if built:
+                results.append(built)
+        return results
+
+    def _locate_body_root(self, soup: BeautifulSoup) -> Optional[Tag]:
+        selectors = [
+            "section.Sections",
+            "section.article-body",
+            "section[id^='body']",
+            "div.article-body",
+        ]
+        for selector in selectors:
+            node = soup.select_one(selector)
+            if isinstance(node, Tag):
+                return node
+        return None
+
+    def _build_body_section(self, node: Tag, fallback_title: Optional[str]) -> Optional[dict[str, Any]]:
+        heading = self.heading_finder(node)
+        title = (heading.get_text(" ", strip=True) if heading else None) or fallback_title or (node.get("id") or "").strip() or None
+
+        html_fragments: List[str] = []
+        children: List[dict[str, Any]] = []
+        subsection_index = 1
+
+        for child in node.children:
+            if isinstance(child, NavigableString):
+                fragment = self._normalise_body_html(child)
+                if fragment:
+                    html_fragments.append(fragment)
+                continue
+            if not isinstance(child, Tag):
+                continue
+            if heading and child is heading:
+                continue
+            if self.section_predicate(child):
+                if title or fallback_title:
+                    basis = title or fallback_title or "Section"
+                    child_fallback = f"{basis} {subsection_index}"
+                else:
+                    child_fallback = f"Section {subsection_index}"
+                subsection_index += 1
+                built_child = self._build_body_section(child, child_fallback)
+                if built_child:
+                    children.append(built_child)
+                continue
+            fragment = self._normalise_body_html(child)
+            if fragment:
+                html_fragments.append(fragment)
+
+        html_content = "".join(html_fragments).strip()
+        if html_content:
+            html_content = self.citation_annotator.annotate_fragment(html_content)
+        if not html_content and not children:
+            return None
+
+        data: dict[str, Any] = {
+            "title": title or fallback_title or "",
+            "html": html_content,
+        }
+        if children:
+            data["children"] = children
+        return data
+
+    def _normalise_body_html(self, node: Tag | NavigableString) -> str:
+        if isinstance(node, NavigableString):
+            text = str(node).strip()
+            if not text:
+                return ""
+            fragment = f"<p>{html.escape(text)}</p>"
+            return self.citation_annotator.annotate_fragment(fragment)
+        if not isinstance(node, Tag):
+            return ""
+        if node.name in {"script", "style"}:
+            return ""
+        if self.section_predicate(node):
+            return ""
+        if node.name == "div":
+            inner = node.decode_contents().strip()
+            if not inner:
+                return ""
+            fragment = f"<p>{inner}</p>"
+            return self.citation_annotator.annotate_fragment(fragment)
+        if node.name == "p":
+            return self.citation_annotator.annotate_fragment(node.decode().strip())
+        return node.decode().strip()

--- a/paperclip/parsers/sites/sciencedirect/body.py
+++ b/paperclip/parsers/sites/sciencedirect/body.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import html
+import re
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional
 
 from bs4 import BeautifulSoup, NavigableString, Tag
 
@@ -91,13 +92,18 @@ class BodyExtractor:
         html_content = "".join(html_fragments).strip()
         if html_content:
             html_content = self.citation_annotator.annotate_fragment(html_content)
-        if not html_content and not children:
+        paragraphs = self._html_to_paragraphs(html_content)
+        markdown = self._join_paragraph_markdown(paragraphs)
+
+        if not markdown and not paragraphs and not children:
             return None
 
         data: dict[str, Any] = {
             "title": title or fallback_title or "",
-            "html": html_content,
+            "markdown": markdown,
         }
+        if paragraphs:
+            data["paragraphs"] = paragraphs
         if children:
             data["children"] = children
         return data
@@ -108,7 +114,7 @@ class BodyExtractor:
             if not text:
                 return ""
             fragment = f"<p>{html.escape(text)}</p>"
-            return self.citation_annotator.annotate_fragment(fragment)
+            return fragment
         if not isinstance(node, Tag):
             return ""
         if node.name in {"script", "style"}:
@@ -120,7 +126,192 @@ class BodyExtractor:
             if not inner:
                 return ""
             fragment = f"<p>{inner}</p>"
-            return self.citation_annotator.annotate_fragment(fragment)
+            return fragment
         if node.name == "p":
-            return self.citation_annotator.annotate_fragment(node.decode().strip())
+            return node.decode().strip()
         return node.decode().strip()
+
+    def _html_to_paragraphs(self, html_content: str) -> List[dict[str, Any]]:
+        if not html_content:
+            return []
+        soup = BeautifulSoup(f"<wrapper>{html_content}</wrapper>", "html.parser")
+        paragraphs: List[dict[str, Any]] = []
+        for element in list(soup.wrapper.contents):
+            if isinstance(element, NavigableString):
+                text = self._clean_text(str(element))
+                if not text:
+                    continue
+                markdown = self._clean_markdown(text)
+                if not markdown:
+                    continue
+                paragraphs.append(
+                    {
+                        "type": "text",
+                        "markdown": markdown,
+                        "sentences": [{"markdown": markdown, "citations": []}],
+                    }
+                )
+                continue
+            if not isinstance(element, Tag):
+                continue
+            if element.name == "p":
+                markdown = self._markdown_from_nodes(element.contents)
+                sentences = self._sentence_segments(element)
+                if not sentences and markdown:
+                    sentences = [{"markdown": markdown, "citations": []}]
+                if markdown or sentences:
+                    paragraphs.append(
+                        {
+                            "type": "paragraph",
+                            "markdown": markdown,
+                            "sentences": sentences,
+                        }
+                    )
+                continue
+            if element.name in {"ul", "ol"}:
+                ordered = element.name == "ol"
+                for index, li in enumerate(element.find_all("li", recursive=False), start=1):
+                    li_markdown = self._markdown_from_nodes(li.contents)
+                    sentences = self._sentence_segments(li)
+                    if not sentences and li_markdown:
+                        sentences = [{"markdown": li_markdown, "citations": []}]
+                    if not li_markdown and not sentences:
+                        continue
+                    prefix = f"{index}. " if ordered else "- "
+                    item_markdown = f"{prefix}{li_markdown}".strip()
+                    paragraphs.append(
+                        {
+                            "type": "list_item",
+                            "list_type": "ordered" if ordered else "unordered",
+                            "markdown": item_markdown,
+                            "sentences": sentences,
+                        }
+                    )
+                continue
+            markdown = self._markdown_from_nodes(element.contents)
+            sentences = self._sentence_segments(element)
+            if not sentences and markdown:
+                sentences = [{"markdown": markdown, "citations": []}]
+            if not markdown and not sentences:
+                continue
+            paragraphs.append(
+                {
+                    "type": element.name,
+                    "markdown": markdown,
+                    "sentences": sentences,
+                }
+            )
+        return paragraphs
+
+    def _sentence_segments(self, block: Tag) -> List[dict[str, Any]]:
+        segments: List[dict[str, Any]] = []
+
+        def flush_buffer(buffer: List[Any]) -> None:
+            if not buffer:
+                return
+            markdown = self._markdown_from_nodes(buffer)
+            if markdown:
+                segments.append({"markdown": markdown, "citations": []})
+            buffer.clear()
+
+        buffer: List[Any] = []
+
+        for child in block.contents:
+            if isinstance(child, Tag) and child.has_attr("data-citation-refs"):
+                if child.find_parent(lambda p: isinstance(p, Tag) and p is not block and p.has_attr("data-citation-refs")):
+                    # Skip nested citation spans; they'll be handled with the outer span.
+                    buffer.append(child)
+                    continue
+                flush_buffer(buffer)
+                refs = [ref for ref in child.get("data-citation-refs", "").split() if ref]
+                markdown = self._markdown_from_nodes(child.contents)
+                if markdown:
+                    segments.append({"markdown": markdown, "citations": refs})
+                continue
+            buffer.append(child)
+
+        flush_buffer(buffer)
+        return [segment for segment in segments if segment.get("markdown")]
+
+    def _markdown_from_nodes(self, nodes: Iterable[Tag | NavigableString]) -> str:
+        parts: List[str] = []
+        for node in nodes:
+            parts.append(self._node_to_markdown(node))
+        return self._clean_markdown("".join(parts))
+
+    def _node_to_markdown(self, node: Tag | NavigableString) -> str:
+        if isinstance(node, NavigableString):
+            return self._clean_text(str(node))
+        if not isinstance(node, Tag):
+            return ""
+        name = node.name.lower()
+        if name in {"script", "style"}:
+            return ""
+        if node.has_attr("data-citation-refs"):
+            return self._markdown_from_nodes(node.contents)
+        if name in {"span", "div"}:
+            return self._markdown_from_nodes(node.contents)
+        if name in {"em", "i"}:
+            inner = self._markdown_from_nodes(node.contents)
+            return f"*{inner}*" if inner else ""
+        if name in {"strong", "b"}:
+            inner = self._markdown_from_nodes(node.contents)
+            return f"**{inner}**" if inner else ""
+        if name == "code":
+            inner = self._markdown_from_nodes(node.contents)
+            return f"`{inner}`" if inner else ""
+        if name == "a":
+            inner = self._markdown_from_nodes(node.contents)
+            href = (node.get("href") or "").strip()
+            if not inner:
+                return ""
+            if href:
+                return f"[{inner}]({href})"
+            return inner
+        if name == "sup":
+            inner = self._markdown_from_nodes(node.contents)
+            return f"^{inner}" if inner else ""
+        if name == "sub":
+            inner = self._markdown_from_nodes(node.contents)
+            return f"~{inner}" if inner else ""
+        if name == "br":
+            return "\n"
+        if name in {"ul", "ol"}:
+            items: List[str] = []
+            ordered = name == "ol"
+            for index, li in enumerate(node.find_all("li", recursive=False), start=1):
+                item = self._markdown_from_nodes(li.contents)
+                if not item:
+                    continue
+                prefix = f"{index}. " if ordered else "- "
+                items.append(f"{prefix}{item}")
+            return "\n".join(items)
+        if name == "li":
+            return self._markdown_from_nodes(node.contents)
+        return self._markdown_from_nodes(node.contents)
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        return value.replace("\xa0", " ")
+
+    @staticmethod
+    def _clean_markdown(value: str) -> str:
+        if not value:
+            return ""
+        text = value
+        text = text.replace("\xa0", " ")
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\s*\n\s*", "\n", text)
+        return text.strip()
+
+    @staticmethod
+    def _join_paragraph_markdown(paragraphs: List[dict[str, Any]]) -> str:
+        if not paragraphs:
+            return ""
+        chunks: List[str] = []
+        for para in paragraphs:
+            chunk = para.get("markdown", "").strip()
+            if not chunk:
+                continue
+            chunks.append(chunk)
+        return "\n\n".join(chunks)

--- a/paperclip/parsers/sites/sciencedirect/citations.py
+++ b/paperclip/parsers/sites/sciencedirect/citations.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+from bs4 import BeautifulSoup
+
+
+class SentenceCitationAnnotator:
+    """Annotate sentences with the reference ids they mention."""
+
+    TAG_PATTERN = re.compile(r"<[^>]+>")
+
+    def annotate_fragment(self, html_fragment: str) -> str:
+        """Return ``html_fragment`` with citation metadata spans inserted."""
+        if not html_fragment:
+            return html_fragment
+
+        soup = BeautifulSoup(f"<wrapper>{html_fragment}</wrapper>", "html.parser")
+        modified = False
+        for block in soup.wrapper.find_all(["p", "li"], recursive=True):
+            original = block.decode_contents()
+            updated = self._wrap_sentence_citations(original)
+            if updated == original:
+                continue
+            replacement = BeautifulSoup(f"<wrapper>{updated}</wrapper>", "html.parser")
+            block.clear()
+            for child in list(replacement.wrapper.contents):
+                block.append(child)
+            modified = True
+
+        if not modified:
+            return html_fragment
+        return soup.wrapper.decode_contents()
+
+    def _wrap_sentence_citations(self, html_fragment: str) -> str:
+        if not html_fragment:
+            return html_fragment
+
+        tags: List[str] = []
+
+        def _store_tag(match: re.Match[str]) -> str:
+            tags.append(match.group(0))
+            return f"@@TAG{len(tags) - 1}@@"
+
+        tokenised = self.TAG_PATTERN.sub(_store_tag, html_fragment)
+        sentences = self._split_sentences(tokenised)
+        if not sentences:
+            return html_fragment
+
+        rebuilt: List[str] = []
+        for sentence in sentences:
+            refs = self._extract_sentence_references(sentence, tags)
+            restored = self._restore_tokens(sentence, tags)
+            if refs:
+                leading_ws = re.match(r"^\s*", restored)
+                trailing_ws = re.search(r"\s*$", restored)
+                leading = leading_ws.group(0) if leading_ws else ""
+                trailing = trailing_ws.group(0) if trailing_ws else ""
+                core = restored[len(leading): len(restored) - len(trailing) if trailing else len(restored)]
+                span = f'<span data-citation-refs="{" ".join(refs)}">{core}</span>'
+                rebuilt.append(f"{leading}{span}{trailing}")
+            else:
+                rebuilt.append(restored)
+        return "".join(rebuilt)
+
+    @staticmethod
+    def _restore_tokens(text: str, tags: List[str]) -> str:
+        if not text:
+            return text
+        return re.sub(r"@@TAG(\d+)@@", lambda m: tags[int(m.group(1))], text)
+
+    def _extract_sentence_references(self, sentence: str, tags: List[str]) -> List[str]:
+        refs: List[str] = []
+        seen: set[str] = set()
+        for match in re.finditer(r"@@TAG(\d+)@@", sentence):
+            tag_index = int(match.group(1))
+            tag_text = tags[tag_index]
+            ref_id = self._reference_id_from_tag(tag_text)
+            if not ref_id or ref_id in seen:
+                continue
+            seen.add(ref_id)
+            refs.append(ref_id)
+        return refs
+
+    @staticmethod
+    def _reference_id_from_tag(tag_text: str) -> Optional[str]:
+        if not tag_text.lower().startswith("<a"):
+            return None
+        href_match = re.search(r'href="#([^"#]+)"', tag_text, flags=re.I)
+        if href_match:
+            candidate = href_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        data_id_match = re.search(r'data-xocs-content-id="([^"#]+)"', tag_text, flags=re.I)
+        if data_id_match:
+            candidate = data_id_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        name_match = re.search(r'name="([^"#]+)"', tag_text, flags=re.I)
+        if name_match:
+            candidate = name_match.group(1).strip()
+            if candidate and "bib" in candidate.lower():
+                return candidate
+        return None
+
+    @staticmethod
+    def _split_sentences(text: str) -> List[str]:
+        sentences: List[str] = []
+        start = 0
+        length = len(text)
+        i = 0
+        while i < length:
+            char = text[i]
+            if char in ".?!":
+                j = i + 1
+                while j < length and text[j] in ")\"]":
+                    j += 1
+                next_char = text[j] if j < length else ""
+                next_token = text[j:j + 6]
+                if j >= length or next_char.isspace() or next_token.startswith("@@TAG"):
+                    segment = text[start:j]
+                    if segment:
+                        sentences.append(segment)
+                    while j < length and text[j].isspace():
+                        sentences.append(text[j])
+                        j += 1
+                    start = j
+                    i = j
+                    continue
+            i += 1
+        if start < length:
+            sentences.append(text[start:])
+        return sentences

--- a/paperclip/parsers/sites/sciencedirect/parser.py
+++ b/paperclip/parsers/sites/sciencedirect/parser.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
-import html
+
 import re
 from typing import Any, Iterable, Optional
 
 from urllib.parse import parse_qsl, urlparse
 
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, Tag
 
-from ..base import BaseParser, ReferenceObj, DOI_RE
+from ...base import BaseParser, ReferenceObj, DOI_RE
+from .body import BodyExtractor
+from .citations import SentenceCitationAnnotator
 
 class ScienceDirectParser(BaseParser):
     NAME = "ScienceDirect"
     DOMAINS = ("sciencedirect.com", "elsevier.com")
     SECTION_ID_RE = re.compile(r"^cesec", re.I)
+    _citation_annotator = SentenceCitationAnnotator()
+    _body_extractor: Optional[BodyExtractor] = None
 
     @classmethod
     def detect(cls, url: str, soup: BeautifulSoup) -> bool:
@@ -389,239 +393,18 @@ class ScienceDirectParser(BaseParser):
 
     @classmethod
     def _extract_body_sections(cls, soup: BeautifulSoup) -> list[dict[str, Any]]:
-        body_root = cls._locate_body_root(soup)
-        sections: list[Tag] = []
-        if body_root:
-            for child in body_root.find_all("section", recursive=False):
-                if cls._is_sciencedirect_section(child):
-                    sections.append(child)
-        if not sections:
-            for candidate in soup.select("section[id]"):
-                if not cls._is_sciencedirect_section(candidate):
-                    continue
-                if any(
-                    isinstance(parent, Tag)
-                    and parent is not candidate
-                    and cls._is_sciencedirect_section(parent)
-                    for parent in candidate.parents
-                ):
-                    continue
-                sections.append(candidate)
-        results: list[dict[str, Any]] = []
-        for idx, section in enumerate(sections, start=1):
-            built = cls._build_body_section(section, fallback_title=f"Section {idx}")
-            if built:
-                results.append(built)
-        return results
+        extractor = cls._get_body_extractor()
+        return extractor.extract(soup)
 
     @classmethod
-    def _locate_body_root(cls, soup: BeautifulSoup) -> Optional[Tag]:
-        selectors = [
-            "section.Sections",
-            "section.article-body",
-            "section[id^='body']",
-            "div.article-body",
-        ]
-        for selector in selectors:
-            node = soup.select_one(selector)
-            if isinstance(node, Tag):
-                return node
-        return None
-
-    @classmethod
-    def _build_body_section(cls, node: Tag, fallback_title: Optional[str]) -> Optional[dict[str, Any]]:
-        heading = cls._leading_heading(node)
-        title = cls._text(heading) if heading else None
-        title = title or fallback_title or (node.get("id") or "").strip() or None
-
-        html_fragments: list[str] = []
-        children: list[dict[str, Any]] = []
-        subsection_index = 1
-
-        for child in node.children:
-            if isinstance(child, NavigableString):
-                fragment = cls._normalise_body_html(child)
-                if fragment:
-                    html_fragments.append(fragment)
-                continue
-            if not isinstance(child, Tag):
-                continue
-            if heading and child is heading:
-                continue
-            if cls._is_sciencedirect_section(child):
-                child_fallback = None
-                if title or fallback_title:
-                    basis = title or fallback_title or "Section"
-                    child_fallback = f"{basis} {subsection_index}"
-                else:
-                    child_fallback = f"Section {subsection_index}"
-                subsection_index += 1
-                built_child = cls._build_body_section(child, child_fallback)
-                if built_child:
-                    children.append(built_child)
-                continue
-            fragment = cls._normalise_body_html(child)
-            if fragment:
-                html_fragments.append(fragment)
-
-        html_content = "".join(html_fragments).strip()
-        if html_content:
-            html_content = cls._annotate_body_html(html_content)
-        if not html_content and not children:
-            return None
-
-        data: dict[str, Any] = {
-            "title": title or fallback_title or "",
-            "html": html_content,
-        }
-        if children:
-            data["children"] = children
-        return data
-
-    @classmethod
-    def _normalise_body_html(cls, node: Tag | NavigableString) -> str:
-        if isinstance(node, NavigableString):
-            text = str(node).strip()
-            if not text:
-                return ""
-            fragment = f"<p>{html.escape(text)}</p>"
-            return cls._annotate_body_html(fragment)
-        if not isinstance(node, Tag):
-            return ""
-        if node.name in {"script", "style"}:
-            return ""
-        if cls._is_sciencedirect_section(node):
-            return ""
-        if node.name == "div":
-            inner = node.decode_contents().strip()
-            if not inner:
-                return ""
-            fragment = f"<p>{inner}</p>"
-            return cls._annotate_body_html(fragment)
-        if node.name == "p":
-            return cls._annotate_body_html(node.decode().strip())
-        return node.decode().strip()
-
-    @classmethod
-    def _annotate_body_html(cls, html_fragment: str) -> str:
-        if not html_fragment:
-            return html_fragment
-        soup = BeautifulSoup(f"<wrapper>{html_fragment}</wrapper>", "html.parser")
-        modified = False
-        for block in soup.wrapper.find_all(["p", "li"], recursive=True):
-            updated = cls._wrap_sentence_citations(block.decode_contents())
-            if updated != block.decode_contents():
-                block.clear()
-                replacement = BeautifulSoup(f"<wrapper>{updated}</wrapper>", "html.parser")
-                for child in list(replacement.wrapper.contents):
-                    block.append(child)
-                modified = True
-        if not modified:
-            return html_fragment
-        return soup.wrapper.decode_contents()
-
-    @classmethod
-    def _wrap_sentence_citations(cls, html_fragment: str) -> str:
-        if not html_fragment:
-            return html_fragment
-
-        tag_pattern = re.compile(r"<[^>]+>")
-        tags: list[str] = []
-
-        def _store_tag(match: re.Match[str]) -> str:
-            tags.append(match.group(0))
-            return f"@@TAG{len(tags) - 1}@@"
-
-        tokenised = tag_pattern.sub(_store_tag, html_fragment)
-        sentences = cls._split_sentences(tokenised)
-        if not sentences:
-            return html_fragment
-
-        rebuilt: list[str] = []
-        for sentence in sentences:
-            refs = cls._extract_sentence_references(sentence, tags)
-            restored = cls._restore_tokens(sentence, tags)
-            if refs:
-                leading_ws = re.match(r"^\s*", restored)
-                trailing_ws = re.search(r"\s*$", restored)
-                leading = leading_ws.group(0) if leading_ws else ""
-                trailing = trailing_ws.group(0) if trailing_ws else ""
-                core = restored[len(leading): len(restored) - len(trailing) if trailing else len(restored)]
-                span = f'<span data-citation-refs="{" ".join(refs)}">{core}</span>'
-                rebuilt.append(f"{leading}{span}{trailing}")
-            else:
-                rebuilt.append(restored)
-        return "".join(rebuilt)
-
-    @staticmethod
-    def _restore_tokens(text: str, tags: list[str]) -> str:
-        if not text:
-            return text
-        return re.sub(r"@@TAG(\d+)@@", lambda m: tags[int(m.group(1))], text)
-
-    @classmethod
-    def _extract_sentence_references(cls, sentence: str, tags: list[str]) -> list[str]:
-        refs: list[str] = []
-        seen: set[str] = set()
-        for match in re.finditer(r"@@TAG(\d+)@@", sentence):
-            tag_index = int(match.group(1))
-            tag_text = tags[tag_index]
-            ref_id = cls._reference_id_from_tag(tag_text)
-            if not ref_id or ref_id in seen:
-                continue
-            seen.add(ref_id)
-            refs.append(ref_id)
-        return refs
-
-    @staticmethod
-    def _reference_id_from_tag(tag_text: str) -> Optional[str]:
-        if not tag_text.lower().startswith("<a"):
-            return None
-        href_match = re.search(r'href="#([^"#]+)"', tag_text, flags=re.I)
-        if href_match:
-            candidate = href_match.group(1).strip()
-            if candidate and "bib" in candidate.lower():
-                return candidate
-        data_id_match = re.search(r'data-xocs-content-id="([^"#]+)"', tag_text, flags=re.I)
-        if data_id_match:
-            candidate = data_id_match.group(1).strip()
-            if candidate and "bib" in candidate.lower():
-                return candidate
-        name_match = re.search(r'name="([^"#]+)"', tag_text, flags=re.I)
-        if name_match:
-            candidate = name_match.group(1).strip()
-            if candidate and "bib" in candidate.lower():
-                return candidate
-        return None
-
-    @staticmethod
-    def _split_sentences(text: str) -> list[str]:
-        sentences: list[str] = []
-        start = 0
-        length = len(text)
-        i = 0
-        while i < length:
-            char = text[i]
-            if char in ".?!":
-                j = i + 1
-                while j < length and text[j] in ")\"]":
-                    j += 1
-                next_char = text[j] if j < length else ""
-                next_token = text[j:j + 6]
-                if j >= length or next_char.isspace() or next_token.startswith("@@TAG"):
-                    segment = text[start:j]
-                    if segment:
-                        sentences.append(segment)
-                    while j < length and text[j].isspace():
-                        sentences.append(text[j])
-                        j += 1
-                    start = j
-                    i = j
-                    continue
-            i += 1
-        if start < length:
-            sentences.append(text[start:])
-        return sentences
+    def _get_body_extractor(cls) -> BodyExtractor:
+        if cls._body_extractor is None:
+            cls._body_extractor = BodyExtractor(
+                citation_annotator=cls._citation_annotator,
+                section_predicate=cls._is_sciencedirect_section,
+                heading_finder=BaseParser._leading_heading,
+            )
+        return cls._body_extractor
 
     @classmethod
     def _is_sciencedirect_section(cls, node: Tag) -> bool:

--- a/paperclip/parsers/sites/sciencedirect_content_plan.md
+++ b/paperclip/parsers/sites/sciencedirect_content_plan.md
@@ -33,7 +33,8 @@ Extend `ScienceDirectParser` so it captures the full body content (introduction,
    - Convert repeated `<div>` wrappers into `<p>` tags or at least ensure line breaks when serializing.
    - Strip leading/trailing whitespace but avoid collapsing purposeful line breaks.
 5. **Populate `content_sections`.**
-   - Add a new key (e.g., `"body"`) whose value is an ordered list of dictionaries: `[{"title": "CONCLUSIONS", "html": "<p>…</p>"}, …]`.
+   - Add a new key (e.g., `"body"`) whose value is an ordered list of dictionaries: `[{"title": "CONCLUSIONS", "markdown": "…", "paragraphs": [...]}, …]`.
+   - Each paragraph entry should expose Markdown text plus a sentence-level breakdown with associated citation ids so downstream consumers can target specific statements.
    - When headings are missing, fall back to sequential numbering (`Section 1`, `Section 2`, …) so the client can still render the text.
    - Preserve the existing abstract/keyword behavior in `_build_content_sections` and append the body sections after them.
 6. **Testing strategy.**

--- a/paperclip/parsers/sites/sciencedirect_content_plan.md
+++ b/paperclip/parsers/sites/sciencedirect_content_plan.md
@@ -1,0 +1,49 @@
+# ScienceDirect article body parsing plan
+
+## Goal
+Extend `ScienceDirectParser` so it captures the full body content (introduction, methods, results, etc.) from ScienceDirect article pages in a structured way that is consistent with the rest of the parser pipeline.
+
+## Observed markup
+- Article body sections live under `<section id="cesec…">` blocks. Each block contains a heading (`<h2>` with classes like `u-h4`) followed by one or more content containers (`<div class="u-margin-s-bottom" …>`). The example snippet below shows the `CONCLUSIONS` section:
+  ```html
+  <section id="cesec150">
+    <h2 class="u-h4 …">CONCLUSIONS</h2>
+    <div class="u-margin-s-bottom" id="para460">…</div>
+  </section>
+  ```
+- The body container for a page typically looks like `<section class="Abstracts" …>` followed by `<section class="Sections" …>`; each numbered `cesec` section corresponds to a visible heading in the article.
+- Paragraph text is wrapped in `div` elements rather than `<p>` tags (ScienceDirect uses spans and nested inline tags inside those divs).
+- Some sections contain subheadings (e.g., `<h3>` or `<h4>` inside the same `section` block) or nested `<section>` children for subsections.
+- Non-body sections we must ignore while iterating: graphical abstracts/highlights, references, author info blocks, footnotes, etc.
+
+## Proposed extraction steps
+1. **Locate the article body root.**
+   - Select the container that holds the main sections (e.g., `section[id^='body']` or `section.article-body`).
+   - If not found, fall back to scanning the entire document for `section[id^='cesec']` to keep the parser resilient.
+2. **Iterate main sections.**
+   - For each top-level `section[id^='cesec']` that is a direct child of the body container:
+     - Extract the heading text from the first `<h2>` or fallback to `<h3>/<h4>`.
+     - Collect the sibling content nodes until the next top-level section. Accept both `<div>` paragraphs and nested section blocks.
+     - Normalize whitespace and preserve inline HTML (italics, math, links) for downstream rendering.
+3. **Handle subsections.**
+   - If we encounter nested `<section>` elements (`<section id="cesec150s0005">` style ids), treat them as subsections. Represent them as nested structures: `{"title": "Subheading", "html": "…"}` under the parent section’s `children` list.
+   - Ensure we keep the DOM order intact, including alternating paragraphs and subheadings.
+4. **Clean and normalize content.**
+   - Remove editorial artifacts (e.g., `data-locator` anchors, `span` wrappers used for styling) while preserving semantic tags (`<em>`, `<strong>`, `<a>`).
+   - Convert repeated `<div>` wrappers into `<p>` tags or at least ensure line breaks when serializing.
+   - Strip leading/trailing whitespace but avoid collapsing purposeful line breaks.
+5. **Populate `content_sections`.**
+   - Add a new key (e.g., `"body"`) whose value is an ordered list of dictionaries: `[{"title": "CONCLUSIONS", "html": "<p>…</p>"}, …]`.
+   - When headings are missing, fall back to sequential numbering (`Section 1`, `Section 2`, …) so the client can still render the text.
+   - Preserve the existing abstract/keyword behavior in `_build_content_sections` and append the body sections after them.
+6. **Testing strategy.**
+   - Create fixture HTML snippets that cover:
+     - Plain paragraphs within a section (like the CONCLUSIONS example).
+     - Sections containing nested subsections/subheadings.
+     - Pages with proxy-modified hosts to ensure detection still works.
+   - Add unit tests validating that `content_sections["body"]` contains the expected titles and HTML, and that abstract/keywords remain untouched.
+
+## Open questions / follow-ups
+- Verify whether tables/figures embedded within sections need additional handling (e.g., capture them separately or leave inside the section HTML).
+- Confirm whether we should expose a flat Markdown string in addition to the structured HTML for compatibility with the rest of the app.
+- Investigate if ScienceDirect ever omits the `cesec` id pattern; if so, expand selectors accordingly.

--- a/paperclip/tests/test_sciencedirect.py
+++ b/paperclip/tests/test_sciencedirect.py
@@ -139,19 +139,77 @@ SCIENCEDIRECT_BODY_HTML = """
 EXPECTED_BODY_SECTIONS = [
     {
         "title": "Introduction",
-        "html": "<p>First paragraph with <em>emphasis</em>.</p><p>Second paragraph.</p>",
+        "markdown": "First paragraph with *emphasis*.\n\nSecond paragraph.",
+        "paragraphs": [
+            {
+                "type": "paragraph",
+                "markdown": "First paragraph with *emphasis*.",
+                "sentences": [
+                    {"markdown": "First paragraph with *emphasis*.", "citations": []},
+                ],
+            },
+            {
+                "type": "paragraph",
+                "markdown": "Second paragraph.",
+                "sentences": [
+                    {"markdown": "Second paragraph.", "citations": []},
+                ],
+            },
+        ],
     },
     {
         "title": "Methods",
-        "html": "<p>Overview paragraph.</p>",
+        "markdown": "Overview paragraph.",
+        "paragraphs": [
+            {
+                "type": "paragraph",
+                "markdown": "Overview paragraph.",
+                "sentences": [
+                    {"markdown": "Overview paragraph.", "citations": []},
+                ],
+            }
+        ],
         "children": [
-            {"title": "Sampling", "html": "<p>Sampling details.</p>"},
-            {"title": "Analysis", "html": "<p>Analysis paragraph.</p>"},
+            {
+                "title": "Sampling",
+                "markdown": "Sampling details.",
+                "paragraphs": [
+                    {
+                        "type": "paragraph",
+                        "markdown": "Sampling details.",
+                        "sentences": [
+                            {"markdown": "Sampling details.", "citations": []},
+                        ],
+                    }
+                ],
+            },
+            {
+                "title": "Analysis",
+                "markdown": "Analysis paragraph.",
+                "paragraphs": [
+                    {
+                        "type": "paragraph",
+                        "markdown": "Analysis paragraph.",
+                        "sentences": [
+                            {"markdown": "Analysis paragraph.", "citations": []},
+                        ],
+                    }
+                ],
+            },
         ],
     },
     {
         "title": "Section 3",
-        "html": "<p>Paragraph without a heading.</p>",
+        "markdown": "Paragraph without a heading.",
+        "paragraphs": [
+            {
+                "type": "paragraph",
+                "markdown": "Paragraph without a heading.",
+                "sentences": [
+                    {"markdown": "Paragraph without a heading.", "citations": []},
+                ],
+            }
+        ],
     },
 ]
 
@@ -175,14 +233,41 @@ SCIENCEDIRECT_BODY_WITH_CITATIONS_HTML = """
 EXPECTED_BODY_WITH_CITATIONS = [
     {
         "title": "Background",
-        "html": (
-            "<p><span data-citation-refs=\"bib48 bib22 bib80\">Infectious diseases impact productivity (<a class=\"anchor\" href=\"#bib48\" data-xocs-content-id=\"bib48\">Hernandez et al., 2001</a>; "
-            "<a class=\"anchor\" href=\"#bib22\" data-xocs-content-id=\"bib22\">Chi et al., 2002</a>; <a class=\"anchor\" href=\"#bib80\" data-xocs-content-id=\"bib80\">Ott et al., 2003</a>).</span> "
-            "<span data-citation-refs=\"bib16 bib8\">In addition, consumer concerns remain (<a class=\"anchor\" href=\"#bib16\" data-xocs-content-id=\"bib16\">Bharti et al., 2003</a>; "
-            "<a class=\"anchor\" href=\"#bib8\" data-xocs-content-id=\"bib8\">Barkema et al., 2015</a>).</span> "
-            "<span data-citation-refs=\"bib108\">Although emerging outbreaks draw attention (<a class=\"anchor\" href=\"#bib108\" data-xocs-content-id=\"bib108\">Wierup, 2012</a>).</span> "
-            "Several important endemic diseases remain major challenges.</p>"
+        "markdown": (
+            "Infectious diseases impact productivity ([Hernandez et al., 2001](#bib48); [Chi et al., 2002](#bib22); "
+            "[Ott et al., 2003](#bib80)). In addition, consumer concerns remain ([Bharti et al., 2003](#bib16); "
+            "[Barkema et al., 2015](#bib8)). Although emerging outbreaks draw attention ([Wierup, 2012](#bib108)). "
+            "Several important endemic diseases remain major challenges."
         ),
+        "paragraphs": [
+            {
+                "type": "paragraph",
+                "markdown": (
+                    "Infectious diseases impact productivity ([Hernandez et al., 2001](#bib48); [Chi et al., 2002](#bib22); "
+                    "[Ott et al., 2003](#bib80)). In addition, consumer concerns remain ([Bharti et al., 2003](#bib16); "
+                    "[Barkema et al., 2015](#bib8)). Although emerging outbreaks draw attention ([Wierup, 2012](#bib108)). "
+                    "Several important endemic diseases remain major challenges."
+                ),
+                "sentences": [
+                    {
+                        "markdown": "Infectious diseases impact productivity ([Hernandez et al., 2001](#bib48); [Chi et al., 2002](#bib22); [Ott et al., 2003](#bib80)).",
+                        "citations": ["bib48", "bib22", "bib80"],
+                    },
+                    {
+                        "markdown": "In addition, consumer concerns remain ([Bharti et al., 2003](#bib16); [Barkema et al., 2015](#bib8)).",
+                        "citations": ["bib16", "bib8"],
+                    },
+                    {
+                        "markdown": "Although emerging outbreaks draw attention ([Wierup, 2012](#bib108)).",
+                        "citations": ["bib108"],
+                    },
+                    {
+                        "markdown": "Several important endemic diseases remain major challenges.",
+                        "citations": [],
+                    },
+                ],
+            }
+        ],
     }
 ]
 

--- a/paperclip/tests/test_sciencedirect.py
+++ b/paperclip/tests/test_sciencedirect.py
@@ -156,6 +156,37 @@ EXPECTED_BODY_SECTIONS = [
 ]
 
 
+SCIENCEDIRECT_BODY_WITH_CITATIONS_HTML = """
+<html>
+  <body>
+    <section class="Sections" id="body0010">
+      <section id="cesec10">
+        <h2 class="u-h4">Background</h2>
+        <div class="u-margin-s-bottom" id="para10">
+          Infectious diseases impact productivity (<a class="anchor" href="#bib48" data-xocs-content-id="bib48">Hernandez et al., 2001</a>; <a class="anchor" href="#bib22" data-xocs-content-id="bib22">Chi et al., 2002</a>; <a class="anchor" href="#bib80" data-xocs-content-id="bib80">Ott et al., 2003</a>). In addition, consumer concerns remain (<a class="anchor" href="#bib16" data-xocs-content-id="bib16">Bharti et al., 2003</a>; <a class="anchor" href="#bib8" data-xocs-content-id="bib8">Barkema et al., 2015</a>). Although emerging outbreaks draw attention (<a class="anchor" href="#bib108" data-xocs-content-id="bib108">Wierup, 2012</a>). Several important endemic diseases remain major challenges.
+        </div>
+      </section>
+    </section>
+  </body>
+</html>
+"""
+
+
+EXPECTED_BODY_WITH_CITATIONS = [
+    {
+        "title": "Background",
+        "html": (
+            "<p><span data-citation-refs=\"bib48 bib22 bib80\">Infectious diseases impact productivity (<a class=\"anchor\" href=\"#bib48\" data-xocs-content-id=\"bib48\">Hernandez et al., 2001</a>; "
+            "<a class=\"anchor\" href=\"#bib22\" data-xocs-content-id=\"bib22\">Chi et al., 2002</a>; <a class=\"anchor\" href=\"#bib80\" data-xocs-content-id=\"bib80\">Ott et al., 2003</a>).</span> "
+            "<span data-citation-refs=\"bib16 bib8\">In addition, consumer concerns remain (<a class=\"anchor\" href=\"#bib16\" data-xocs-content-id=\"bib16\">Bharti et al., 2003</a>; "
+            "<a class=\"anchor\" href=\"#bib8\" data-xocs-content-id=\"bib8\">Barkema et al., 2015</a>).</span> "
+            "<span data-citation-refs=\"bib108\">Although emerging outbreaks draw attention (<a class=\"anchor\" href=\"#bib108\" data-xocs-content-id=\"bib108\">Wierup, 2012</a>).</span> "
+            "Several important endemic diseases remain major challenges.</p>"
+        ),
+    }
+]
+
+
 def test_extracts_expected_abstract() -> None:
     soup = BeautifulSoup(SCIENCEDIRECT_SAMPLE_HTML, "html.parser")
     abstract = ScienceDirectParser._extract_abstract(soup)
@@ -189,6 +220,12 @@ def test_extracts_body_sections() -> None:
     url = "https://www.sciencedirect.com/science/article/pii/S9876543210987654"
     parsed = parse_html(url, SCIENCEDIRECT_BODY_HTML)
     assert parsed.content_sections["body"] == EXPECTED_BODY_SECTIONS
+
+
+def test_body_sentences_include_reference_annotations() -> None:
+    url = "https://www.sciencedirect.com/science/article/pii/S2468135799999999"
+    parsed = parse_html(url, SCIENCEDIRECT_BODY_WITH_CITATIONS_HTML)
+    assert parsed.content_sections["body"] == EXPECTED_BODY_WITH_CITATIONS
 
 
 SCIENCEDIRECT_REFERENCES_HTML = """

--- a/paperclip/tests/test_sciencedirect.py
+++ b/paperclip/tests/test_sciencedirect.py
@@ -106,6 +106,56 @@ EXPECTED_KEYWORDS = [
 ]
 
 
+SCIENCEDIRECT_BODY_HTML = """
+<html>
+  <body>
+    <section class="Sections" id="body0010">
+      <section id="cesec10">
+        <h2 class="u-h4">Introduction</h2>
+        <div class="u-margin-s-bottom" id="para10">First paragraph with <em>emphasis</em>.</div>
+        <div class="u-margin-s-bottom" id="para20">Second paragraph.</div>
+      </section>
+      <section id="cesec20">
+        <h2 class="u-h4">Methods</h2>
+        <div class="u-margin-s-bottom">Overview paragraph.</div>
+        <section id="cesec20s0005">
+          <h3>Sampling</h3>
+          <div>Sampling details.</div>
+        </section>
+        <section id="cesec20s0010">
+          <h3>Analysis</h3>
+          <div>Analysis paragraph.</div>
+        </section>
+      </section>
+      <section id="cesec30">
+        <div class="u-margin-s-bottom">Paragraph without a heading.</div>
+      </section>
+    </section>
+  </body>
+</html>
+"""
+
+
+EXPECTED_BODY_SECTIONS = [
+    {
+        "title": "Introduction",
+        "html": "<p>First paragraph with <em>emphasis</em>.</p><p>Second paragraph.</p>",
+    },
+    {
+        "title": "Methods",
+        "html": "<p>Overview paragraph.</p>",
+        "children": [
+            {"title": "Sampling", "html": "<p>Sampling details.</p>"},
+            {"title": "Analysis", "html": "<p>Analysis paragraph.</p>"},
+        ],
+    },
+    {
+        "title": "Section 3",
+        "html": "<p>Paragraph without a heading.</p>",
+    },
+]
+
+
 def test_extracts_expected_abstract() -> None:
     soup = BeautifulSoup(SCIENCEDIRECT_SAMPLE_HTML, "html.parser")
     abstract = ScienceDirectParser._extract_abstract(soup)
@@ -133,6 +183,12 @@ def test_content_sections_include_abstract_for_server_view() -> None:
     assert "abstract" not in meta
     assert parsed.content_sections["abstract"] == EXPECTED_ABSTRACT
     assert parsed.content_sections["keywords"] == EXPECTED_KEYWORDS
+
+
+def test_extracts_body_sections() -> None:
+    url = "https://www.sciencedirect.com/science/article/pii/S9876543210987654"
+    parsed = parse_html(url, SCIENCEDIRECT_BODY_HTML)
+    assert parsed.content_sections["body"] == EXPECTED_BODY_SECTIONS
 
 
 SCIENCEDIRECT_REFERENCES_HTML = """

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,0 +1,1 @@
+python manage.py runserver 127.0.0.1:8000


### PR DESCRIPTION
## Summary
- extend the ScienceDirect parser to capture article body sections and attach them to parsed content
- normalise ScienceDirect paragraph markup into HTML fragments and recurse through nested subsections
- add unit coverage that exercises body extraction with headings, nested sections, and fallback titles

## Testing
- pytest paperclip/tests/test_sciencedirect.py *(skipped: bs4 not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0684f66ec8329927fa28ef22cf950