### PR TITLE
Add fallback to base body extractor for Wiley sections

### DIFF
--- a/paperclip/parsers/sites/sciencedirect/body.py
+++ b/paperclip/parsers/sites/sciencedirect/body.py
@@ -57,14 +57,17 @@ class BodyExtractor:
         return None
 
     def _build_body_section(self, node: Tag, fallback_title: Optional[str]) -> Optional[dict[str, Any]]:
+        content_root = self._content_root(node)
         heading = self.heading_finder(node)
+        if heading is None and content_root is not node:
+            heading = self.heading_finder(content_root)
         title = (heading.get_text(" ", strip=True) if heading else None) or fallback_title or (node.get("id") or "").strip() or None
 
         html_fragments: List[str] = []
         children: List[dict[str, Any]] = []
         subsection_index = 1
 
-        for child in node.children:
+        for child in content_root.children:
             if isinstance(child, NavigableString):
                 fragment = self._normalise_body_html(child)
                 if fragment:
@@ -107,6 +110,9 @@ class BodyExtractor:
         if children:
             data["children"] = children
         return data
+
+    def _content_root(self, node: Tag) -> Tag:
+        return node
 
     def _normalise_body_html(self, node: Tag | NavigableString) -> str:
         if isinstance(node, NavigableString):

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -1,8 +1,97 @@
 from __future__ import annotations
 from urllib.parse import urlparse
+from typing import ClassVar
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
+
 from ..base import BaseParser, ReferenceObj, DOI_RE
+from .sciencedirect.body import BodyExtractor
+from .sciencedirect.citations import SentenceCitationAnnotator
+
+
+class WileyBodyExtractor(BodyExtractor):
+    def extract(self, soup: BeautifulSoup) -> list[dict[str, object]]:  # type: ignore[override]
+        body_root = self._locate_body_root(soup)
+        sections: list[Tag] = []
+        seen: set[int] = set()
+
+        def consider(node: Tag) -> None:
+            if not isinstance(node, Tag):
+                return
+            if not self.section_predicate(node):
+                return
+            if any(
+                isinstance(parent, Tag)
+                and parent is not node
+                and self.section_predicate(parent)
+                for parent in node.parents
+            ):
+                return
+            marker = id(node)
+            if marker in seen:
+                return
+            seen.add(marker)
+            sections.append(node)
+
+        if body_root:
+            for child in body_root.find_all("section", recursive=False):
+                consider(child)
+
+        if not sections:
+            for candidate in soup.select("section[id]"):
+                consider(candidate)
+
+        if not sections:
+            for candidate in soup.select("section.article-section, section.article-section__content"):
+                consider(candidate)
+
+        if not sections:
+            return super().extract(soup)
+
+        results: list[dict[str, object]] = []
+        for idx, section in enumerate(sections, start=1):
+            built = self._build_body_section(section, fallback_title=f"Section {idx}")
+            if built:
+                results.append(built)
+        return results
+
+    def _content_root(self, node: Tag) -> Tag:  # type: ignore[override]
+        if node.name != "section":
+            return node
+        for child in node.find_all(True, recursive=False):
+            if child.name != "div":
+                continue
+            classes = {
+                value.lower()
+                for value in (child.get("class") or [])
+                if isinstance(value, str)
+            }
+            if any(class_name.startswith("article-section__content") for class_name in classes):
+                return child
+        return node
+
+    def _locate_body_root(self, soup: BeautifulSoup) -> Tag | None:  # type: ignore[override]
+        selectors = [
+            "div.article__sections",
+            "div.article__body",
+            "section.article-body",
+            "div#pb-page-content",
+            "div#article-body",
+            "div#main-content",
+            "article.article",
+        ]
+        for selector in selectors:
+            node = soup.select_one(selector)
+            if isinstance(node, Tag):
+                return node
+
+        first_section = soup.select_one("section.article-section__content")
+        if isinstance(first_section, Tag):
+            parent = first_section.parent
+            if isinstance(parent, Tag):
+                return parent
+
+        return super()._locate_body_root(soup)
 
 class WileyParser(BaseParser):
     NAME = "Wiley"
@@ -11,6 +100,7 @@ class WileyParser(BaseParser):
         "div.abstract-group div.article-section__content",
         "section.article-section__abstract div.article-section__content",
     )
+    _body_extractor: ClassVar[BodyExtractor | None] = None
 
     @classmethod
     def detect(cls, url: str, soup: BeautifulSoup) -> bool:
@@ -64,3 +154,53 @@ class WileyParser(BaseParser):
             return refs
 
         return super()._harvest_references_generic(soup)
+
+    @classmethod
+    def _build_content_sections(cls, soup: BeautifulSoup) -> dict[str, object]:
+        content = super()._build_content_sections(soup)
+        body_sections = cls._extract_body_sections(soup)
+        if body_sections:
+            content["body"] = body_sections
+        return content
+
+    @classmethod
+    def _extract_body_sections(cls, soup: BeautifulSoup) -> list[dict[str, object]]:
+        extractor = cls._get_body_extractor()
+        return extractor.extract(soup)
+
+    @classmethod
+    def _get_body_extractor(cls) -> BodyExtractor:
+        if cls._body_extractor is None:
+            cls._body_extractor = WileyBodyExtractor(
+                citation_annotator=SentenceCitationAnnotator(),
+                section_predicate=cls._is_wiley_section,
+                heading_finder=BaseParser._leading_heading,
+            )
+        return cls._body_extractor
+
+    @classmethod
+    def _is_wiley_section(cls, node: Tag) -> bool:
+        if node.name != "section":
+            return False
+        classes = {
+            value.lower()
+            for value in (node.get("class") or [])
+            if isinstance(value, str)
+        }
+        if not classes:
+            content = node.find(
+                class_=lambda name: isinstance(name, str)
+                and name.lower().startswith("article-section__content")
+            )
+            return bool(content)
+        if "article-section__content" in classes:
+            return True
+        if "article-section" in classes and node.find(
+            class_=lambda name: isinstance(name, str)
+            and name.lower().startswith("article-section__content")
+        ):
+            return True
+        return any(
+            class_name.startswith("article-section__content")
+            for class_name in classes
+        )

--- a/paperclip/tests/test_wiley.py
+++ b/paperclip/tests/test_wiley.py
@@ -79,8 +79,60 @@ STRUCTURED_EXPECTED_ABSTRACT = [
             "The same clones were found in animals and humans, which may infer that both farm and pet animals may act as potential vehicles of infection for humans. Some other clones seem to be less widely distributed. Clustering analysis of genomic fingerprints of Salmonella Dublin and Salm. Enteritidis isolates confirms the existence of a close phylogenetic relationship between both serotypes. "
             "Significance and Impact of the Study: This paper describes the utility of a multiple genetic typing approach for Salm. Dublin. It gives useful information on clonal diversity among human and animal isolates."
         ),
-    }
+    },
 ]
+
+WILEY_BODY_HTML = """
+<html>
+<body>
+<main>
+<section class="article-section__content" id="section-1">
+<h2 class="article-section__title section__title">Introduction</h2>
+<p>Application of post-Sanger sequencing technologies in ecology has accelerated since the introduction of Restriction site Associated DNA sequencing (RADseq; Baird <i>et&nbsp;al.</i> <a href="#bib-1">2008</a>).</p>
+<div class="article-table-content" id="table-1">
+<header class="article-table-caption"><span class="table-caption__label">Table 1.</span> Example comparison</header>
+<div class="article-table-content-wrapper" tabindex="0">
+<table class="table article-section__table">
+<tbody>
+<tr>
+<td>RAD</td>
+<td>1</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="article-section__table-footnotes">
+<ul>
+<li>n: no; y: yes.</li>
+</ul>
+</div>
+</div>
+<p>As a result, confusion may arise as to which protocol is appropriate.</p>
+</section>
+</main>
+</body>
+</html>
+"""
+
+
+WILEY_NESTED_BODY_HTML = """
+<html>
+  <body>
+    <div class="article__sections">
+      <section class="article-section" data-section-type="body">
+        <div class="article-section__content" id="section-2">
+          <h2 class="article-section__title section__title">Methods</h2>
+          <p>Sequencing libraries were prepared using a custom protocol.</p>
+          <section class="article-section__content--sub" id="section-2-1">
+            <h3 class="article-section__title section__subtitle">Sampling</h3>
+            <p>We sampled ten locations spanning the native range.</p>
+          </section>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>
+"""
 
 
 def test_wiley_parser_extracts_abstract_from_article_section() -> None:
@@ -105,3 +157,45 @@ def test_wiley_parser_detects_proxied_domains_for_server_capture() -> None:
     proxied_url = "https://onlinelibrary-wiley-com.ezproxy.example.edu/doi/full/10.1002/example"
     parsed = parse_html(proxied_url, STRUCTURED_WILEY_HTML)
     assert parsed.content_sections["abstract"] == STRUCTURED_EXPECTED_ABSTRACT
+
+
+
+def test_wiley_parser_extracts_body_sections() -> None:
+    url = "https://onlinelibrary.wiley.com/doi/10.1002/example"
+    parsed = parse_html(url, WILEY_BODY_HTML)
+    body = parsed.content_sections["body"]
+    assert body
+    first = body[0]
+    assert first["title"].strip() == "Introduction"
+    paragraphs = first.get("paragraphs") or []
+    assert any(
+        paragraph.get("markdown", "").startswith("Application of post-Sanger sequencing technologies")
+        for paragraph in paragraphs
+    )
+    assert any(
+        "Table 1." in paragraph.get("markdown", "")
+        for paragraph in paragraphs
+    )
+
+
+def test_wiley_parser_handles_nested_section_wrappers() -> None:
+    url = "https://onlinelibrary.wiley.com/doi/10.1002/example"
+    parsed = parse_html(url, WILEY_NESTED_BODY_HTML)
+    body = parsed.content_sections["body"]
+    assert body
+    first = body[0]
+    assert first["title"].strip() == "Methods"
+    paragraphs = first.get("paragraphs") or []
+    assert any(
+        paragraph.get("markdown", "").startswith("Sequencing libraries were prepared")
+        for paragraph in paragraphs
+    )
+    children = first.get("children") or []
+    assert children
+    child = children[0]
+    assert child["title"].strip() == "Sampling"
+    child_paragraphs = child.get("paragraphs") or []
+    assert any(
+        "sampled ten locations" in paragraph.get("markdown", "")
+        for paragraph in child_paragraphs
+    )


### PR DESCRIPTION
## Summary
- extend the shared ScienceDirect body extractor to support customizable content roots when building body sections
- update the Wiley extractor to reuse the shared section builder, fall back to the base implementation when custom selection fails, and keep its content wrapper override

## Testing
- pytest paperclip/tests/test_wiley.py *(skipped: BeautifulSoup unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1418922b4832990c06587346b9bb3