### PR TITLE
Fix circular import in parser base

### DIFF
--- a/paperclip/parsers/base.py
+++ b/paperclip/parsers/base.py
@@ -437,14 +437,14 @@ class BaseParser:
         caption_node = node.find("figcaption")
         caption_text = cls._normalise_whitespace(cls._text(caption_node)) if caption_node else ""
         label = cls._figure_label(node, caption_node, index)
-        caption = caption_text
+        caption: Optional[str] = caption_text or None
         if caption and label:
-            caption = cls._strip_caption_label(caption, label, prefixes=("figure", "fig"))
+            caption = cls._strip_caption_label(caption, label, prefixes=("figure", "fig")) or caption
         if not caption:
             first_image = node.find("img")
             if isinstance(first_image, Tag):
-                caption = cls._normalise_whitespace(first_image.get("alt") or "")
-        caption = caption or None
+                alt_text = cls._normalise_whitespace(first_image.get("alt") or "")
+                caption = alt_text or caption
 
         images = cls._figure_images(node)
         html_content = node.decode().strip()
@@ -566,10 +566,9 @@ class BaseParser:
     def _build_table(cls, node: Tag, index: int) -> Optional[dict[str, Any]]:
         caption_text = cls._table_caption_text(node)
         label = cls._table_label(node, caption_text, index)
-        caption = caption_text
+        caption: Optional[str] = caption_text or None
         if caption and label:
-            caption = cls._strip_caption_label(caption, label, prefixes=("table",))
-        caption = caption or None
+            caption = cls._strip_caption_label(caption, label, prefixes=("table",)) or caption
 
         html_content = node.decode().strip()
         if not html_content and not caption:

--- a/paperclip/parsers/base.py
+++ b/paperclip/parsers/base.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import re
-from typing import Any, Callable, ClassVar, Mapping, Optional, Sequence, TypedDict
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Mapping, Optional, Sequence, TypedDict
 from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup, NavigableString, Tag
 
-from .sites.sciencedirect.body import BodyExtractor
-from .sites.sciencedirect.citations import SentenceCitationAnnotator
+if TYPE_CHECKING:
+    from .sites.sciencedirect.body import BodyExtractor
+    from .sites.sciencedirect.citations import SentenceCitationAnnotator
 
 # DOI pattern
 DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+\b")
@@ -403,6 +404,9 @@ class BaseParser:
         extractor = getattr(cls, "_body_extractor", None)
         owner = getattr(extractor, "_owner", None)
         if extractor is None or owner is not cls:
+            from .sites.sciencedirect.body import BodyExtractor
+            from .sites.sciencedirect.citations import SentenceCitationAnnotator
+
             extractor = BodyExtractor(
                 citation_annotator=SentenceCitationAnnotator(),
                 section_predicate=cls._is_generic_body_section,

--- a/paperclip/parsers/sites/sciencedirect/parser.py
+++ b/paperclip/parsers/sites/sciencedirect/parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, Optional
+from typing import Any, ClassVar, Iterable, Optional
 
 from urllib.parse import parse_qsl, urlparse
 
@@ -16,7 +16,7 @@ class ScienceDirectParser(BaseParser):
     DOMAINS = ("sciencedirect.com", "elsevier.com")
     SECTION_ID_RE = re.compile(r"^cesec", re.I)
     _citation_annotator = SentenceCitationAnnotator()
-    _body_extractor: Optional[BodyExtractor] = None
+    _body_extractor: ClassVar[Optional[BodyExtractor]] = None
 
     @classmethod
     def detect(cls, url: str, soup: BeautifulSoup) -> bool:

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -1,109 +1,136 @@
 from __future__ import annotations
 from urllib.parse import urlparse
-from typing import ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from bs4 import BeautifulSoup, NavigableString, Tag
 
 from ..base import BaseParser, ReferenceObj, DOI_RE
 from .sciencedirect.body import BodyExtractor
-from .sciencedirect.citations import SentenceCitationAnnotator
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from .sciencedirect.citations import SentenceCitationAnnotator
 
 
 class WileyBodyExtractor(BodyExtractor):
-    def extract(self, soup: BeautifulSoup) -> list[dict[str, object]]:  # type: ignore[override]
+    _SECTION_TAGS: ClassVar[tuple[str, ...]] = ("section", "div")
+
+    def extract(self, soup: BeautifulSoup) -> list[dict[str, Any]]:
         body_root = self._locate_body_root(soup)
-        sections: list[Tag] = []
-        seen: set[int] = set()
-
-        active: set[int] = set()
-
-        def consider(node: Tag) -> None:
-            if not isinstance(node, Tag):
-                return
-
-            if self.section_predicate(node):
-                marker = id(node)
-                if marker in seen:
-                    return
-                if marker in active:
-                    return
-                active.add(marker)
-                child_sections = [
-                    child
-                    for child in node.find_all(["section", "div"], recursive=False)
-                    if isinstance(child, Tag) and self.section_predicate(child)
-                ]
-                if child_sections:
-                    for child in child_sections:
-                        consider(child)
-
-                    has_direct_content = False
-                    for child in node.children:
-                        if isinstance(child, NavigableString):
-                            if child.strip():
-                                has_direct_content = True
-                                break
-                            continue
-                        if not isinstance(child, Tag):
-                            continue
-                        if child in child_sections:
-                            continue
-                        if child.get_text(" ", strip=True):
-                            has_direct_content = True
-                            break
-
-                    if not has_direct_content:
-                        active.discard(marker)
-                        return
-
-                for parent in node.parents:
-                    if not isinstance(parent, Tag) or parent is node:
-                        continue
-                    if not self.section_predicate(parent):
-                        continue
-                    parent_marker = id(parent)
-                    if parent_marker in active:
-                        continue
-                    if parent_marker not in seen:
-                        consider(parent)
-                    if parent_marker in seen:
-                        active.discard(marker)
-                        return
-                seen.add(marker)
-                sections.append(node)
-                active.discard(marker)
-                return
-
-            for child in node.find_all(["section", "div"], recursive=False):
-                consider(child)
-            return
-
-        try:
-            if body_root:
-                for child in body_root.find_all(["section", "div"], recursive=False):
-                    consider(child)
-
-            for selector in (
-                "section[id], div[id]",
-                "section.article-section.article-section__full, div.article-section.article-section__full",
-                "section.article-section, section.article-section__content, div.article-section__content",
-            ):
-                if sections:
-                    break
-                for candidate in soup.select(selector):
-                    consider(candidate)
-        finally:
-            active.clear()
+        sections = self._collect_top_level_sections(soup, body_root)
 
         if not sections:
             return super().extract(soup)
 
-        results: list[dict[str, object]] = []
-        for idx, section in enumerate(sections, start=1):
-            built = self._build_body_section(section, fallback_title=f"Section {idx}")
+        results: list[dict[str, Any]] = []
+        for index, section in enumerate(sections, start=1):
+            built = self._build_body_section(section, fallback_title=f"Section {index}")
             if built:
                 results.append(built)
         return results
+
+    def _collect_top_level_sections(
+        self, soup: BeautifulSoup, body_root: Tag | None
+    ) -> list[Tag]:
+        """Collect Wiley body sections in document order.
+
+        The DOM on Wiley frequently nests structural wrappers around the real
+        section content.  Rather than chasing parents and children recursively,
+        gather every matching node once and then retain the highest level nodes
+        that contain actual content.
+        """
+
+        candidates: list[Tag] = []
+        seen_nodes: set[int] = set()
+
+        def queue_nodes(root: Tag | BeautifulSoup) -> None:
+            if not isinstance(root, Tag):
+                return
+            if self.section_predicate(root):
+                marker = id(root)
+                if marker not in seen_nodes:
+                    seen_nodes.add(marker)
+                    candidates.append(root)
+
+            for node in root.find_all(self._SECTION_TAGS):
+                if not isinstance(node, Tag):
+                    continue
+                marker = id(node)
+                if marker in seen_nodes:
+                    continue
+                if not self.section_predicate(node):
+                    continue
+                seen_nodes.add(marker)
+                candidates.append(node)
+
+        if body_root:
+            queue_nodes(body_root)
+
+        if not candidates:
+            for selector in (
+                "section[id]",
+                "div[id]",
+                "section.article-section",
+                "div.article-section",
+                "div.article-section__content",
+                "section.article-section__content",
+            ):
+                for candidate in soup.select(selector):
+                    if isinstance(candidate, Tag):
+                        queue_nodes(candidate)
+                if candidates:
+                    break
+
+        if not candidates:
+            queue_nodes(soup)
+
+        if not candidates:
+            return []
+
+        top_level: list[Tag] = []
+        skipped_descendants: set[int] = set()
+
+        for node in candidates:
+            marker = id(node)
+            if marker in skipped_descendants:
+                continue
+            if self._has_section_ancestor(node):
+                continue
+            if not self._has_direct_content(node) and self._has_section_descendant(node):
+                continue
+            top_level.append(node)
+            for descendant in node.find_all(self._SECTION_TAGS):
+                if isinstance(descendant, Tag):
+                    skipped_descendants.add(id(descendant))
+
+        return top_level
+
+    def _has_section_ancestor(self, node: Tag) -> bool:
+        for parent in node.parents:
+            if isinstance(parent, Tag) and self.section_predicate(parent):
+                return True
+        return False
+
+    def _has_section_descendant(self, node: Tag) -> bool:
+        for descendant in node.find_all(self._SECTION_TAGS):
+            if descendant is node:
+                continue
+            if isinstance(descendant, Tag) and self.section_predicate(descendant):
+                return True
+        return False
+
+    def _has_direct_content(self, node: Tag) -> bool:
+        for child in node.children:
+            if isinstance(child, NavigableString):
+                if child.strip():
+                    return True
+                continue
+            if not isinstance(child, Tag):
+                continue
+            if self.section_predicate(child):
+                continue
+            if child.get_text(" ", strip=True):
+                return True
+        return False
 
     @staticmethod
     def _leading_heading(node: Tag) -> Tag | None:
@@ -332,6 +359,8 @@ class WileyParser(BaseParser):
     @classmethod
     def _get_body_extractor(cls) -> BodyExtractor:
         if cls._body_extractor is None:
+            from .sciencedirect.citations import SentenceCitationAnnotator
+
             cls._body_extractor = WileyBodyExtractor(
                 citation_annotator=SentenceCitationAnnotator(),
                 section_predicate=cls._is_wiley_section,

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from urllib.parse import urlparse
 from typing import ClassVar
 
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, NavigableString, Tag
 
 from ..base import BaseParser, ReferenceObj, DOI_RE
 from .sciencedirect.body import BodyExtractor
@@ -20,6 +20,33 @@ class WileyBodyExtractor(BodyExtractor):
                 return
 
             if self.section_predicate(node):
+                child_sections = [
+                    child
+                    for child in node.find_all(["section", "div"], recursive=False)
+                    if isinstance(child, Tag) and self.section_predicate(child)
+                ]
+                if child_sections:
+                    for child in child_sections:
+                        consider(child)
+
+                    has_direct_content = False
+                    for child in node.children:
+                        if isinstance(child, NavigableString):
+                            if child.strip():
+                                has_direct_content = True
+                                break
+                            continue
+                        if not isinstance(child, Tag):
+                            continue
+                        if child in child_sections:
+                            continue
+                        if child.get_text(" ", strip=True):
+                            has_direct_content = True
+                            break
+
+                    if not has_direct_content:
+                        return
+
                 for parent in node.parents:
                     if not isinstance(parent, Tag) or parent is node:
                         continue

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -60,19 +60,138 @@ class WileyBodyExtractor(BodyExtractor):
                 results.append(built)
         return results
 
+    @staticmethod
+    def _leading_heading(node: Tag) -> Tag | None:
+        heading = BaseParser._leading_heading(node)
+        if heading:
+            return heading
+
+        heading = node.find(
+            lambda tag: isinstance(tag, Tag)
+            and tag.name in {"h1", "h2", "h3", "h4", "h5", "h6"}
+            and any(
+                isinstance(value, str)
+                and (
+                    "section__title" in value.lower()
+                    or "section__subtitle" in value.lower()
+                    or value.lower().startswith("article-section__title")
+                )
+                for value in (tag.get("class") or [])
+            )
+        )
+        if heading:
+            return heading
+
+        visited: set[str] = set()
+        current: Tag | None = node
+        while isinstance(current, Tag):
+            labelled = current.get("aria-labelledby")
+            if isinstance(labelled, str):
+                for token in labelled.split():
+                    identifier = token.strip()
+                    if not identifier or identifier in visited:
+                        continue
+                    visited.add(identifier)
+                    scope: Tag | None = current
+                    while isinstance(scope, Tag):
+                        found = scope.find(id=identifier)
+                        if isinstance(found, Tag):
+                            return found
+                        scope = scope.parent if isinstance(scope.parent, Tag) else None
+            current = current.parent if isinstance(current.parent, Tag) else None
+
+        return None
+
     def _content_root(self, node: Tag) -> Tag:  # type: ignore[override]
-        if node.name != "section":
+        if node.name == "section":
+            for child in node.find_all(True, recursive=False):
+                classes = {
+                    value.lower()
+                    for value in (child.get("class") or [])
+                    if isinstance(value, str)
+                }
+                if child.name == "div" and any(
+                    class_name.startswith("article-section__content")
+                    or class_name.startswith("article-section__full")
+                    or class_name.startswith("article-section__body")
+                    for class_name in classes
+                ):
+                    return self._content_root(child)
             return node
+
+        classes = {
+            value.lower() for value in (node.get("class") or []) if isinstance(value, str)
+        }
+        data_locator = node.get("data-test-locator") or node.get("data-testid")
+        candidate_children: list[Tag] = []
+
         for child in node.find_all(True, recursive=False):
-            if child.name != "div":
+            if not isinstance(child, Tag):
                 continue
-            classes = {
+            child_classes = {
                 value.lower()
                 for value in (child.get("class") or [])
                 if isinstance(value, str)
             }
-            if any(class_name.startswith("article-section__content") for class_name in classes):
-                return child
+            child_data_locator = child.get("data-test-locator") or child.get("data-testid")
+            child_locator = child_data_locator.lower() if isinstance(child_data_locator, str) else ""
+            if any(
+                class_name.startswith("article-section__content")
+                or class_name.startswith("article-section__full")
+                or class_name.startswith("article-section__sub-content")
+                or class_name.startswith("accordion__panel-body")
+                for class_name in child_classes
+            ) or (child_locator and "article-section" in child_locator):
+                candidate_children.append(child)
+
+        if not candidate_children and isinstance(data_locator, str):
+            locator = data_locator.lower()
+            if "article-section" in locator:
+                for descendant in node.find_all(True):
+                    if not isinstance(descendant, Tag):
+                        continue
+                    descendant_classes = {
+                        value.lower()
+                        for value in (descendant.get("class") or [])
+                        if isinstance(value, str)
+                    }
+                    descendant_data = descendant.get("data-test-locator") or descendant.get("data-testid")
+                    descendant_locator = descendant_data.lower() if isinstance(descendant_data, str) else ""
+                    if any(
+                        class_name.startswith("article-section__content")
+                        or class_name.startswith("article-section__full")
+                        or class_name.startswith("article-section__sub-content")
+                        or class_name.startswith("accordion__panel-body")
+                        for class_name in descendant_classes
+                    ) or (descendant_locator and "article-section" in descendant_locator):
+                        candidate_children.append(descendant)
+                        break
+
+        for child in candidate_children:
+            return self._content_root(child)
+
+        if "accordion__panel" in classes:
+            body = node.find(
+                lambda tag: isinstance(tag, Tag)
+                and (
+                    "accordion__panel-body" in {
+                        value.lower()
+                        for value in (tag.get("class") or [])
+                        if isinstance(value, str)
+                    }
+                    or (
+                        isinstance(tag.get("data-test-locator"), str)
+                        and "article-section" in tag.get("data-test-locator").lower()
+                    )
+                    or (
+                        isinstance(tag.get("data-testid"), str)
+                        and "article-section" in tag.get("data-testid").lower()
+                    )
+                )
+            )
+            if isinstance(body, Tag):
+                return self._content_root(body)
+
         return node
 
     def _locate_body_root(self, soup: BeautifulSoup) -> Tag | None:  # type: ignore[override]
@@ -171,7 +290,7 @@ class WileyParser(BaseParser):
             cls._body_extractor = WileyBodyExtractor(
                 citation_annotator=SentenceCitationAnnotator(),
                 section_predicate=cls._is_wiley_section,
-                heading_finder=BaseParser._leading_heading,
+                heading_finder=WileyBodyExtractor._leading_heading,
             )
         return cls._body_extractor
 

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -184,16 +184,35 @@ class WileyParser(BaseParser):
             for value in (node.get("class") or [])
             if isinstance(value, str)
         }
+
+        if any("abstract" in class_name for class_name in classes):
+            return False
+
+        data_section_type = node.get("data-section-type")
+        if isinstance(data_section_type, str) and data_section_type.lower() in {
+            "body",
+            "full",
+            "fulltext",
+            "article-body",
+        }:
+            return True
+
+        data_locator = node.get("data-test-locator") or node.get("data-testid")
+        if isinstance(data_locator, str) and "article-section" in data_locator.lower():
+            return True
+
         if not classes:
             content = node.find(
                 class_=lambda name: isinstance(name, str)
                 and name.lower().startswith("article-section__content")
             )
-            return bool(content)
+            if content:
+                return True
 
         if any(
             class_name.startswith("article-section__content")
             or class_name.startswith("article-section__sub-content")
+            or class_name.startswith("article-section__full")
             for class_name in classes
         ):
             return True
@@ -203,5 +222,32 @@ class WileyParser(BaseParser):
             and name.lower().startswith("article-section__content")
         ):
             return True
+
+        heading = node.find(
+            lambda tag: isinstance(tag, Tag)
+            and any(
+                isinstance(value, str)
+                and (
+                    "article-section__title" in value.lower()
+                    or "article-section__sub-title" in value.lower()
+                    or "section__title" in value.lower()
+                    or "section__subtitle" in value.lower()
+                )
+                for value in (tag.get("class") or [])
+            )
+        )
+        if heading:
+            text = heading.get_text(" ", strip=True).lower()
+            if text and "abstract" in text:
+                return False
+            return True
+
+        labelled = node.get("aria-labelledby")
+        if isinstance(labelled, str) and labelled.strip():
+            heading = node.find(id=labelled.strip())
+            if isinstance(heading, Tag):
+                text = heading.get_text(" ", strip=True).lower()
+                if text and "abstract" not in text:
+                    return True
 
         return False

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -15,11 +15,19 @@ class WileyBodyExtractor(BodyExtractor):
         sections: list[Tag] = []
         seen: set[int] = set()
 
+        active: set[int] = set()
+
         def consider(node: Tag) -> None:
             if not isinstance(node, Tag):
                 return
 
             if self.section_predicate(node):
+                marker = id(node)
+                if marker in seen:
+                    return
+                if marker in active:
+                    return
+                active.add(marker)
                 child_sections = [
                     child
                     for child in node.find_all(["section", "div"], recursive=False)
@@ -45,6 +53,7 @@ class WileyBodyExtractor(BodyExtractor):
                             break
 
                     if not has_direct_content:
+                        active.discard(marker)
                         return
 
                 for parent in node.parents:
@@ -53,33 +62,38 @@ class WileyBodyExtractor(BodyExtractor):
                     if not self.section_predicate(parent):
                         continue
                     parent_marker = id(parent)
+                    if parent_marker in active:
+                        continue
                     if parent_marker not in seen:
                         consider(parent)
                     if parent_marker in seen:
+                        active.discard(marker)
                         return
-                marker = id(node)
-                if marker in seen:
-                    return
                 seen.add(marker)
                 sections.append(node)
+                active.discard(marker)
                 return
 
             for child in node.find_all(["section", "div"], recursive=False):
                 consider(child)
+            return
 
-        if body_root:
-            for child in body_root.find_all(["section", "div"], recursive=False):
-                consider(child)
+        try:
+            if body_root:
+                for child in body_root.find_all(["section", "div"], recursive=False):
+                    consider(child)
 
-        for selector in (
-            "section[id], div[id]",
-            "section.article-section.article-section__full, div.article-section.article-section__full",
-            "section.article-section, section.article-section__content, div.article-section__content",
-        ):
-            if sections:
-                break
-            for candidate in soup.select(selector):
-                consider(candidate)
+            for selector in (
+                "section[id], div[id]",
+                "section.article-section.article-section__full, div.article-section.article-section__full",
+                "section.article-section, section.article-section__content, div.article-section__content",
+            ):
+                if sections:
+                    break
+                for candidate in soup.select(selector):
+                    consider(candidate)
+        finally:
+            active.clear()
 
         if not sections:
             return super().extract(soup)

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -20,13 +20,16 @@ class WileyBodyExtractor(BodyExtractor):
                 return
 
             if self.section_predicate(node):
-                if any(
-                    isinstance(parent, Tag)
-                    and parent is not node
-                    and self.section_predicate(parent)
-                    for parent in node.parents
-                ):
-                    return
+                for parent in node.parents:
+                    if not isinstance(parent, Tag) or parent is node:
+                        continue
+                    if not self.section_predicate(parent):
+                        continue
+                    parent_marker = id(parent)
+                    if parent_marker not in seen:
+                        consider(parent)
+                    if parent_marker in seen:
+                        return
                 marker = id(node)
                 if marker in seen:
                     return
@@ -43,6 +46,7 @@ class WileyBodyExtractor(BodyExtractor):
 
         for selector in (
             "section[id], div[id]",
+            "section.article-section.article-section__full, div.article-section.article-section__full",
             "section.article-section, section.article-section__content, div.article-section__content",
         ):
             if sections:

--- a/paperclip/parsers/sites/wiley.py
+++ b/paperclip/parsers/sites/wiley.py
@@ -160,6 +160,7 @@ class WileyParser(BaseParser):
 
         return super()._harvest_references_generic(soup)
 
+    @classmethod
     def _extract_body_sections(cls, soup: BeautifulSoup) -> list[dict[str, object]]:
         extractor = cls._get_body_extractor()
         return extractor.extract(soup)

--- a/paperclip/tests/test_wiley.py
+++ b/paperclip/tests/test_wiley.py
@@ -186,6 +186,22 @@ WILEY_COMPLEX_BODY_HTML = """
 """
 
 
+WILEY_FULL_SECTION_NO_KNOWN_ROOT_HTML = """
+<html>
+  <body>
+    <div id="article-wrapper">
+      <div class="article-section article-section__full">
+        <div class="article-section__content" id="sec-main">
+          <h2 class="article-section__title section__title">Overview</h2>
+          <p>The overview content introduces the article themes.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+"""
+
+
 WILEY_ACCORDION_BODY_HTML = """
 <html>
   <body>
@@ -345,6 +361,20 @@ def test_wiley_parser_handles_complex_full_sections() -> None:
     data_input = next(child for child in children if child.get("title", "").strip() == "Data input")
     child_paragraphs = data_input.get("paragraphs") or []
     assert any("ref.DNAseq" in paragraph.get("markdown", "") for paragraph in child_paragraphs)
+
+
+def test_wiley_parser_handles_full_sections_without_known_root() -> None:
+    url = "https://onlinelibrary.wiley.com/doi/10.1002/example"
+    parsed = parse_html(url, WILEY_FULL_SECTION_NO_KNOWN_ROOT_HTML)
+    body = parsed.content_sections["body"]
+    assert body
+    overview = body[0]
+    assert overview["title"].strip() == "Overview"
+    paragraphs = overview.get("paragraphs") or []
+    assert any(
+        "overview content introduces" in paragraph.get("markdown", "").lower()
+        for paragraph in paragraphs
+    )
 
 
 def test_wiley_parser_handles_accordion_panels() -> None:

--- a/paperclip/tests/test_wiley.py
+++ b/paperclip/tests/test_wiley.py
@@ -208,6 +208,46 @@ WILEY_ACCORDION_BODY_HTML = """
 """
 
 
+WILEY_ACCORDION_WITH_HEADER_HTML = """
+<html>
+  <body>
+    <div id="pb-page-content">
+      <div class="accordion" id="article-sections">
+        <div class="accordion__panel" data-testid="article-section">
+          <div class="accordion__panel-header">
+            <button class="accordion__panel-title" id="sec-a-title">Introduction</button>
+          </div>
+          <div
+            class="accordion__panel-body"
+            id="sec-a"
+            aria-labelledby="sec-a-title"
+            data-test-locator="article-section-content"
+          >
+            <div class="article-section__content">
+              <p>The introductory panel content describes the study background.</p>
+            </div>
+          </div>
+        </div>
+        <div class="accordion__panel" data-testid="article-section">
+          <div class="accordion__panel-header">
+            <button class="accordion__panel-title" id="sec-b-title">SimRAD workflow and functions</button>
+          </div>
+          <div class="accordion__panel-body" id="sec-b" aria-labelledby="sec-b-title">
+            <div class="accordion__panel-content">
+              <section class="article-section__content" id="men12273-sec-0002">
+                <h2 class="article-section__title section__title">SimRAD workflow and functions</h2>
+                <p>A subsample or the full reference genome sequence of a species can be used to simulate restriction enzyme digestion.</p>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+"""
+
+
 def test_wiley_parser_extracts_abstract_from_article_section() -> None:
     soup = BeautifulSoup(WILEY_SAMPLE_HTML, "html.parser")
     abstract = WileyParser._extract_abstract(soup)
@@ -329,3 +369,29 @@ def test_wiley_parser_handles_accordion_panels() -> None:
         for paragraph in results_paragraphs
     )
 
+
+def test_wiley_parser_handles_accordion_header_titles() -> None:
+    url = "https://onlinelibrary.wiley.com/doi/10.1002/example"
+    parsed = parse_html(url, WILEY_ACCORDION_WITH_HEADER_HTML)
+    body = parsed.content_sections["body"]
+    assert body
+    titles = {section.get("title", "").strip() for section in body}
+    assert {"Introduction", "SimRAD workflow and functions"}.issubset(titles)
+
+    intro = next(section for section in body if section.get("title", "").strip() == "Introduction")
+    intro_paragraphs = intro.get("paragraphs") or []
+    assert any(
+        "study background" in paragraph.get("markdown", "")
+        for paragraph in intro_paragraphs
+    )
+
+    workflow = next(
+        section
+        for section in body
+        if section.get("title", "").strip() == "SimRAD workflow and functions"
+    )
+    workflow_paragraphs = workflow.get("paragraphs") or []
+    assert any(
+        "full reference genome sequence" in paragraph.get("markdown", "")
+        for paragraph in workflow_paragraphs
+    )

--- a/paperclip/tests/test_wiley.py
+++ b/paperclip/tests/test_wiley.py
@@ -186,6 +186,28 @@ WILEY_COMPLEX_BODY_HTML = """
 """
 
 
+WILEY_ACCORDION_BODY_HTML = """
+<html>
+  <body>
+    <div class="accordion" id="article-sections">
+      <div class="accordion__panel" data-test-locator="article-section">
+        <div class="accordion__panel-body" data-test-locator="article-section-content" id="sec-1">
+          <h2 class="section__title">Introduction</h2>
+          <p>The introductory panel content describes the scope of the study.</p>
+        </div>
+      </div>
+      <div class="accordion__panel" data-testid="article-section">
+        <div class="accordion__panel-body" id="sec-2" aria-labelledby="sec-2-title">
+          <h2 class="section__title" id="sec-2-title">Results</h2>
+          <p>The results panel summarises the main findings.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+"""
+
+
 def test_wiley_parser_extracts_abstract_from_article_section() -> None:
     soup = BeautifulSoup(WILEY_SAMPLE_HTML, "html.parser")
     abstract = WileyParser._extract_abstract(soup)
@@ -283,3 +305,27 @@ def test_wiley_parser_handles_complex_full_sections() -> None:
     data_input = next(child for child in children if child.get("title", "").strip() == "Data input")
     child_paragraphs = data_input.get("paragraphs") or []
     assert any("ref.DNAseq" in paragraph.get("markdown", "") for paragraph in child_paragraphs)
+
+
+def test_wiley_parser_handles_accordion_panels() -> None:
+    url = "https://onlinelibrary.wiley.com/doi/10.1002/example"
+    parsed = parse_html(url, WILEY_ACCORDION_BODY_HTML)
+    body = parsed.content_sections["body"]
+    assert body
+    titles = {section.get("title", "").strip() for section in body}
+    assert {"Introduction", "Results"}.issubset(titles)
+
+    intro = next(section for section in body if section.get("title", "").strip() == "Introduction")
+    intro_paragraphs = intro.get("paragraphs") or []
+    assert any(
+        "introductory panel content" in paragraph.get("markdown", "")
+        for paragraph in intro_paragraphs
+    )
+
+    results = next(section for section in body if section.get("title", "").strip() == "Results")
+    results_paragraphs = results.get("paragraphs") or []
+    assert any(
+        "summarises the main findings" in paragraph.get("markdown", "")
+        for paragraph in results_paragraphs
+    )
+


### PR DESCRIPTION
## Summary
- avoid eagerly importing the ScienceDirect body extraction helpers in `BaseParser`
- perform a lazy import inside `_get_body_extractor` to break the circular reference when loading ScienceDirect parsers

## Testing
- python manage.py check *(fails: Django not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16d1a13c083299f871a8c7a6293ea