### PR TITLE
Add markdown-only capture content artifact

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -34,9 +34,10 @@ function findMainElement() {
 
 function collectReferences(root) {
   const out = [];
+  const scope = root && typeof root.querySelectorAll === "function" ? root : document;
   const doiRe = /\b10\.\d{4,9}\/[-._;()/:A-Za-z0-9]+\b/;
   // Try heading "References/Bibliography/Works Cited"
-  const headers = [...document.querySelectorAll("h1,h2,h3,h4,h5,h6")];
+  const headers = [...scope.querySelectorAll("h1,h2,h3,h4,h5,h6")];
   let refBlock = null;
   for (const h of headers) {
     if (/(references|bibliography|works cited)/i.test(h.textContent || "")) {
@@ -44,11 +45,37 @@ function collectReferences(root) {
       let sib = h.nextElementSibling;
       while (sib && !/^(OL|UL|DIV|SECTION)$/i.test(sib.tagName)) sib = sib.nextElementSibling;
       if (sib) { refBlock = sib; break; }
+
+      // Fallback: search within the heading's parent containers for a list
+      let parent = h.parentElement;
+      while (parent && parent !== scope && !refBlock) {
+        const candidate = parent.querySelector("ol, ul");
+        if (candidate && candidate.querySelector("li")) {
+          refBlock = candidate;
+          break;
+        }
+        parent = parent.parentElement;
+      }
     }
   }
   if (!refBlock) {
-    refBlock = document.querySelector("ol.references, ul.references, #references ol, #references ul, .references ol, .references ul");
+    refBlock = scope.querySelector(
+      "ol.references, ul.references, #references ol, #references ul, .references ol, .references ul, section.article-section__references ol, div.article-section__references ol"
+    );
   }
+  if (!refBlock) {
+    const wileyTab = scope.querySelector("#pcw-references, #pane-pcw-references, [data-tab='pane-pcw-references']");
+    if (wileyTab) {
+      const list = wileyTab.querySelector("ol, ul");
+      if (list) refBlock = list;
+    }
+  }
+
+  if (refBlock && refBlock.tagName && !/^(OL|UL)$/i.test(refBlock.tagName)) {
+    const nested = refBlock.querySelector("ol, ul");
+    if (nested) refBlock = nested;
+  }
+
   const items = refBlock ? [...refBlock.querySelectorAll("li")] : [];
   items.forEach((li, i) => {
     const raw = (li.innerText || "").trim();

--- a/paperclip/api.py
+++ b/paperclip/api.py
@@ -153,6 +153,29 @@ def _content_sections_to_markdown_paragraphs(
     if not isinstance(content, Mapping):
         return {}
 
+    def _split_markdown_chunks(markdown: str) -> list[str]:
+        if not markdown.strip():
+            return []
+
+        chunks: list[str] = []
+        buffer: list[str] = []
+        for line in markdown.splitlines():
+            if not line.strip():
+                if buffer:
+                    chunk = "\n".join(buffer).strip()
+                    if chunk:
+                        chunks.append(chunk)
+                    buffer = []
+                continue
+            buffer.append(line.rstrip())
+
+        if buffer:
+            chunk = "\n".join(buffer).strip()
+            if chunk:
+                chunks.append(chunk)
+
+        return chunks
+
     def _extract_paragraphs(raw: Any) -> list[str]:
         paragraphs: list[str] = []
         if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
@@ -176,11 +199,12 @@ def _content_sections_to_markdown_paragraphs(
         if isinstance(title, str) and title.strip():
             simplified["title"] = title.strip()
 
-        markdown = section.get("markdown")
-        if isinstance(markdown, str) and markdown.strip():
-            simplified["markdown"] = markdown.strip()
-
         paragraphs = _extract_paragraphs(section.get("paragraphs"))
+        if not paragraphs:
+            markdown = section.get("markdown")
+            if isinstance(markdown, str):
+                paragraphs = _split_markdown_chunks(markdown)
+
         if paragraphs:
             simplified["paragraphs"] = paragraphs
 
@@ -252,13 +276,18 @@ def _build_markdown_capture_view(
     content: Mapping[str, Any] | None,
     meta: Mapping[str, Any] | None,
     references: Sequence[Mapping[str, Any]] | None,
+    title: str | None = None,
 ) -> dict[str, Any]:
     """Produce a lightweight markdown-friendly capture view."""
 
     view: dict[str, Any] = {}
 
-    if isinstance(meta, Mapping) and meta:
-        view["metadata"] = dict(meta)
+    metadata: dict[str, Any] = {}
+    if isinstance(meta, Mapping):
+        metadata.update(meta)
+    if title and not metadata.get("title"):
+        metadata["title"] = title
+    view["metadata"] = metadata
 
     simplified_sections = _content_sections_to_markdown_paragraphs(content)
     for key, value in simplified_sections.items():
@@ -271,8 +300,102 @@ def _build_markdown_capture_view(
             data = dict(ref)
             if data:
                 normalized_refs.append(data)
+
+    def _append_section_markdown(
+        sections: Sequence[Mapping[str, Any]] | None,
+        *,
+        level: int,
+        lines: list[str],
+    ) -> None:
+        if not sections:
+            return
+
+        for section in sections:
+            if not isinstance(section, Mapping):
+                continue
+            title_text = section.get("title")
+            heading_level = max(1, min(level, 6))
+            if isinstance(title_text, str) and title_text.strip():
+                lines.append(f"{'#' * heading_level} {title_text.strip()}")
+                lines.append("")
+
+            paragraphs = section.get("paragraphs")
+            if isinstance(paragraphs, Sequence) and not isinstance(paragraphs, (str, bytes)):
+                for paragraph in paragraphs:
+                    if isinstance(paragraph, str) and paragraph.strip():
+                        lines.append(paragraph.strip())
+                        lines.append("")
+
+            children = section.get("children")
+            if isinstance(children, Sequence) and not isinstance(children, (str, bytes)):
+                _append_section_markdown(children, level=heading_level + 1, lines=lines)
+
+    markdown_lines: list[str] = []
+
+    if metadata:
+        markdown_lines.append("## Metadata")
+        markdown_lines.append("")
+        for key in sorted(metadata):
+            value = metadata[key]
+            if value is None:
+                continue
+            rendered = str(value).strip()
+            if rendered:
+                pretty_key = key.replace("_", " ").strip()
+                markdown_lines.append(f"- **{pretty_key}**: {rendered}")
+        markdown_lines.append("")
+
+    abstract_sections = simplified_sections.get("abstract")
+    if isinstance(abstract_sections, Sequence) and abstract_sections:
+        markdown_lines.append("## Abstract")
+        markdown_lines.append("")
+        _append_section_markdown(
+            cast(Sequence[Mapping[str, Any]] | None, abstract_sections),
+            level=3,
+            lines=markdown_lines,
+        )
+
+    body_sections = simplified_sections.get("body")
+    if isinstance(body_sections, Sequence) and body_sections:
+        markdown_lines.append("## Body")
+        markdown_lines.append("")
+        _append_section_markdown(
+            cast(Sequence[Mapping[str, Any]] | None, body_sections),
+            level=3,
+            lines=markdown_lines,
+        )
+
+    keywords = simplified_sections.get("keywords")
+    if isinstance(keywords, Sequence) and keywords:
+        markdown_lines.append("## Keywords")
+        markdown_lines.append("")
+        keyword_items = [str(word).strip() for word in keywords if str(word).strip()]
+        if keyword_items:
+            markdown_lines.append(", ".join(keyword_items))
+            markdown_lines.append("")
+
+    view["markdown"] = "\n".join(line for line in markdown_lines if line is not None).strip()
+
+    view["references"] = normalized_refs
+
     if normalized_refs:
-        view["references"] = normalized_refs
+        ref_lines: list[str] = []
+        ref_lines.append("## References")
+        ref_lines.append("")
+        for idx, ref in enumerate(normalized_refs, start=1):
+            raw = str(ref.get("raw", "")).strip()
+            if raw:
+                ref_lines.append(f"{idx}. {raw}")
+            else:
+                ref_lines.append(f"{idx}. (reference details unavailable)")
+        markdown_fragment = "\n".join(ref_lines)
+        if view["markdown"]:
+            view["markdown"] = f"{view['markdown'].rstrip()}\n\n{markdown_fragment}"
+        else:
+            view["markdown"] = markdown_fragment
+
+    if view["markdown"]:
+        view["markdown"] = view["markdown"].rstrip() + "\n"
 
     return view
 
@@ -572,6 +695,7 @@ class CaptureViewSet(viewsets.ViewSet):
             content=content_sections,
             meta=final_state.get("meta"),
             references=serialized_refs,
+            title=capture.title,
         )
 
         server_view = {

--- a/paperclip/api.py
+++ b/paperclip/api.py
@@ -1,7 +1,7 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
-from typing import Any, Callable, Iterable, Mapping, NamedTuple, TypedDict, cast
+from typing import Any, Callable, Iterable, Mapping, NamedTuple, Sequence, TypedDict, cast
 
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -245,6 +245,36 @@ def _content_sections_to_markdown_paragraphs(
             simplified_content["keywords"] = keyword_values
 
     return simplified_content
+
+
+def _build_markdown_capture_view(
+    *,
+    content: Mapping[str, Any] | None,
+    meta: Mapping[str, Any] | None,
+    references: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    """Produce a lightweight markdown-friendly capture view."""
+
+    view: dict[str, Any] = {}
+
+    if isinstance(meta, Mapping) and meta:
+        view["metadata"] = dict(meta)
+
+    simplified_sections = _content_sections_to_markdown_paragraphs(content)
+    for key, value in simplified_sections.items():
+        if value:
+            view[key] = value
+
+    normalized_refs: list[dict[str, Any]] = []
+    for ref in references or []:
+        if isinstance(ref, Mapping):
+            data = dict(ref)
+            if data:
+                normalized_refs.append(data)
+    if normalized_refs:
+        view["references"] = normalized_refs
+
+    return view
 
 
 class ReferencePayload(TypedDict, total=False):
@@ -529,7 +559,6 @@ class CaptureViewSet(viewsets.ViewSet):
 
         parsed = parse_with_fallback(capture.url, capture.content_html, capture.dom_html)
         content_sections = self._reconcile_parser_results(capture, parsed)
-        content_markdown = _content_sections_to_markdown_paragraphs(content_sections)
 
         final_state = CaptureOutSerializer(capture).data
         write_json_artifact(capture.id, "parsed.json", final_state)
@@ -538,6 +567,12 @@ class CaptureViewSet(viewsets.ViewSet):
             _reference_to_server_view(ref)
             for ref in (final_state.get("references") or [])
         ]
+
+        markdown_view = _build_markdown_capture_view(
+            content=content_sections,
+            meta=final_state.get("meta"),
+            references=serialized_refs,
+        )
 
         server_view = {
             "id": capture.id,
@@ -549,17 +584,17 @@ class CaptureViewSet(viewsets.ViewSet):
         }
         if content_sections:
             server_view["content"] = content_sections
-        if content_markdown:
-            server_view["content_markdown"] = content_markdown
+        if markdown_view:
+            server_view["content_markdown"] = markdown_view
         write_json_artifact(capture.id, "server_parsed.json", server_view)
-        if content_markdown:
-            write_json_artifact(capture.id, "server_parsed_markdown.json", content_markdown)
+        if markdown_view:
+            write_json_artifact(capture.id, "server_parsed_markdown.json", markdown_view)
 
         artifact_urls = self._build_artifact_urls(
             request,
             capture.id,
             bool(enrichment_blob),
-            bool(content_markdown),
+            bool(markdown_view),
         )
 
         refs_qs = capture.references.all()[:3]

--- a/paperclip/api.py
+++ b/paperclip/api.py
@@ -1,7 +1,16 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
-from typing import Any, Callable, Iterable, Mapping, NamedTuple, Sequence, TypedDict, cast
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    TypedDict,
+    cast,
+)
 
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -145,10 +154,39 @@ def apply_doi_enrichment(
     return DoiEnrichmentResult(blob=cast(EnrichmentPayload, blob), doi=doi)
 
 
+JsonMapping = Mapping[str, Any]
+
+
+class MarkdownSection(TypedDict, total=False):
+    """Representation of a parsed section suitable for markdown rendering."""
+
+    title: str
+    paragraphs: list[str]
+    children: list["MarkdownSection"]
+
+
+class MarkdownCaptureView(TypedDict, total=False):
+    """Structure returned by :func:`_build_markdown_capture_view`."""
+
+    metadata: dict[str, Any]
+    abstract: list[MarkdownSection]
+    body: list[MarkdownSection]
+    keywords: list[str]
+    references: list[dict[str, Any]]
+    markdown: str
+
+
 def _content_sections_to_markdown_paragraphs(
-    content: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    """Build a markdown-only view of parsed content sections."""
+    content: JsonMapping | None,
+) -> MarkdownCaptureView:
+    """Normalise parser content into markdown-friendly structures.
+
+    The parser output contains nested structures with optional ``markdown`` and
+    ``paragraphs`` fields.  Consumers that want to work with markdown paragraphs
+    benefit from a simplified structure where each section declares explicit
+    paragraph lists.  This helper performs that normalisation and returns the
+    pieces that can later be rendered into plain markdown text.
+    """
 
     if not isinstance(content, Mapping):
         return {}
@@ -192,8 +230,8 @@ def _content_sections_to_markdown_paragraphs(
                         paragraphs.append(stripped)
         return paragraphs
 
-    def _simplify_body_section(section: Mapping[str, Any]) -> dict[str, Any]:
-        simplified: dict[str, Any] = {}
+    def _simplify_body_section(section: JsonMapping) -> MarkdownSection:
+        simplified: MarkdownSection = {}
 
         title = section.get("title")
         if isinstance(title, str) and title.strip():
@@ -210,7 +248,7 @@ def _content_sections_to_markdown_paragraphs(
 
         children_raw = section.get("children")
         if isinstance(children_raw, Iterable) and not isinstance(children_raw, (str, bytes)):
-            children: list[dict[str, Any]] = []
+            children: list[MarkdownSection] = []
             for child in children_raw:
                 if isinstance(child, Mapping):
                     simplified_child = _simplify_body_section(child)
@@ -221,15 +259,15 @@ def _content_sections_to_markdown_paragraphs(
 
         return simplified
 
-    simplified_content: dict[str, Any] = {}
+    simplified_content: MarkdownCaptureView = {}
 
     abstract_sections = content.get("abstract")
     if isinstance(abstract_sections, Iterable) and not isinstance(abstract_sections, (str, bytes)):
-        abstract_list: list[dict[str, Any]] = []
+        abstract_list: list[MarkdownSection] = []
         for entry in abstract_sections:
             if not isinstance(entry, Mapping):
                 continue
-            simplified_entry: dict[str, Any] = {}
+            simplified_entry: MarkdownSection = {}
             title = entry.get("title")
             if isinstance(title, str) and title.strip():
                 simplified_entry["title"] = title.strip()
@@ -252,7 +290,7 @@ def _content_sections_to_markdown_paragraphs(
 
     body_sections = content.get("body")
     if isinstance(body_sections, Iterable) and not isinstance(body_sections, (str, bytes)):
-        body_list: list[dict[str, Any]] = []
+        body_list: list[MarkdownSection] = []
         for section in body_sections:
             if not isinstance(section, Mapping):
                 continue
@@ -273,14 +311,31 @@ def _content_sections_to_markdown_paragraphs(
 
 def _build_markdown_capture_view(
     *,
-    content: Mapping[str, Any] | None,
-    meta: Mapping[str, Any] | None,
-    references: Sequence[Mapping[str, Any]] | None,
+    content: JsonMapping | None,
+    meta: JsonMapping | None,
+    references: Sequence[JsonMapping] | None,
     title: str | None = None,
-) -> dict[str, Any]:
-    """Produce a lightweight markdown-friendly capture view."""
+) -> MarkdownCaptureView:
+    """Assemble a markdown-friendly representation of the capture data.
 
-    view: dict[str, Any] = {}
+    The resulting dictionary is lightweight but still expressive enough for
+    client consumption:
+
+    ``metadata``
+        Arbitrary metadata values preserved as key/value pairs.  The capture
+        title is injected when available so the markdown view always exposes a
+        top-level heading.
+    ``abstract`` and ``body``
+        Lists of :class:`MarkdownSection` entries with paragraphs suitable for
+        direct rendering.
+    ``references``
+        Normalised reference payloads that mirror the data returned by the API
+        serializer.
+    ``markdown``
+        A fully-rendered markdown string that concatenates the above sections.
+    """
+
+    view: MarkdownCaptureView = {}
 
     metadata: dict[str, Any] = {}
     if isinstance(meta, Mapping):
@@ -302,7 +357,7 @@ def _build_markdown_capture_view(
                 normalized_refs.append(data)
 
     def _append_section_markdown(
-        sections: Sequence[Mapping[str, Any]] | None,
+        sections: Sequence[MarkdownSection] | None,
         *,
         level: int,
         lines: list[str],

--- a/paperclip/api.py
+++ b/paperclip/api.py
@@ -145,6 +145,108 @@ def apply_doi_enrichment(
     return DoiEnrichmentResult(blob=cast(EnrichmentPayload, blob), doi=doi)
 
 
+def _content_sections_to_markdown_paragraphs(
+    content: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a markdown-only view of parsed content sections."""
+
+    if not isinstance(content, Mapping):
+        return {}
+
+    def _extract_paragraphs(raw: Any) -> list[str]:
+        paragraphs: list[str] = []
+        if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+            for entry in raw:
+                if isinstance(entry, Mapping):
+                    text = entry.get("markdown")
+                    if isinstance(text, str):
+                        stripped = text.strip()
+                        if stripped:
+                            paragraphs.append(stripped)
+                elif isinstance(entry, str):
+                    stripped = entry.strip()
+                    if stripped:
+                        paragraphs.append(stripped)
+        return paragraphs
+
+    def _simplify_body_section(section: Mapping[str, Any]) -> dict[str, Any]:
+        simplified: dict[str, Any] = {}
+
+        title = section.get("title")
+        if isinstance(title, str) and title.strip():
+            simplified["title"] = title.strip()
+
+        markdown = section.get("markdown")
+        if isinstance(markdown, str) and markdown.strip():
+            simplified["markdown"] = markdown.strip()
+
+        paragraphs = _extract_paragraphs(section.get("paragraphs"))
+        if paragraphs:
+            simplified["paragraphs"] = paragraphs
+
+        children_raw = section.get("children")
+        if isinstance(children_raw, Iterable) and not isinstance(children_raw, (str, bytes)):
+            children: list[dict[str, Any]] = []
+            for child in children_raw:
+                if isinstance(child, Mapping):
+                    simplified_child = _simplify_body_section(child)
+                    if simplified_child:
+                        children.append(simplified_child)
+            if children:
+                simplified["children"] = children
+
+        return simplified
+
+    simplified_content: dict[str, Any] = {}
+
+    abstract_sections = content.get("abstract")
+    if isinstance(abstract_sections, Iterable) and not isinstance(abstract_sections, (str, bytes)):
+        abstract_list: list[dict[str, Any]] = []
+        for entry in abstract_sections:
+            if not isinstance(entry, Mapping):
+                continue
+            simplified_entry: dict[str, Any] = {}
+            title = entry.get("title")
+            if isinstance(title, str) and title.strip():
+                simplified_entry["title"] = title.strip()
+            body = entry.get("body")
+            paragraphs: list[str] = []
+            if isinstance(body, str):
+                lines = [line.strip() for line in body.splitlines() if line.strip()]
+                if lines:
+                    paragraphs = lines
+                else:
+                    stripped = body.strip()
+                    if stripped:
+                        paragraphs = [stripped]
+            if paragraphs:
+                simplified_entry["paragraphs"] = paragraphs
+            if simplified_entry:
+                abstract_list.append(simplified_entry)
+        if abstract_list:
+            simplified_content["abstract"] = abstract_list
+
+    body_sections = content.get("body")
+    if isinstance(body_sections, Iterable) and not isinstance(body_sections, (str, bytes)):
+        body_list: list[dict[str, Any]] = []
+        for section in body_sections:
+            if not isinstance(section, Mapping):
+                continue
+            simplified_section = _simplify_body_section(section)
+            if simplified_section:
+                body_list.append(simplified_section)
+        if body_list:
+            simplified_content["body"] = body_list
+
+    keywords = content.get("keywords")
+    if isinstance(keywords, Iterable) and not isinstance(keywords, (str, bytes)):
+        keyword_values = [str(value).strip() for value in keywords if str(value).strip()]
+        if keyword_values:
+            simplified_content["keywords"] = keyword_values
+
+    return simplified_content
+
+
 class ReferencePayload(TypedDict, total=False):
     id: str | None
     raw: str
@@ -387,7 +489,11 @@ class CaptureViewSet(viewsets.ViewSet):
         return parsed.content_sections or None
 
     def _build_artifact_urls(
-        self, request: HttpRequest, capture_id: str, enriched: bool
+        self,
+        request: HttpRequest,
+        capture_id: str,
+        enriched: bool,
+        has_markdown_view: bool,
     ) -> dict[str, str]:
         base = request.build_absolute_uri("/").rstrip("/")
         urls = {
@@ -396,6 +502,10 @@ class CaptureViewSet(viewsets.ViewSet):
             "parsed_json": f"{base}/captures/{capture_id}/artifact/parsed.json",
             "server_parsed": f"{base}/captures/{capture_id}/artifact/server_parsed.json",
         }
+        if has_markdown_view:
+            urls["server_parsed_markdown"] = (
+                f"{base}/captures/{capture_id}/artifact/server_parsed_markdown.json"
+            )
         if enriched:
             urls["enrichment"] = f"{base}/captures/{capture_id}/artifact/enrichment.json"
         return urls
@@ -419,6 +529,7 @@ class CaptureViewSet(viewsets.ViewSet):
 
         parsed = parse_with_fallback(capture.url, capture.content_html, capture.dom_html)
         content_sections = self._reconcile_parser_results(capture, parsed)
+        content_markdown = _content_sections_to_markdown_paragraphs(content_sections)
 
         final_state = CaptureOutSerializer(capture).data
         write_json_artifact(capture.id, "parsed.json", final_state)
@@ -438,9 +549,18 @@ class CaptureViewSet(viewsets.ViewSet):
         }
         if content_sections:
             server_view["content"] = content_sections
+        if content_markdown:
+            server_view["content_markdown"] = content_markdown
         write_json_artifact(capture.id, "server_parsed.json", server_view)
+        if content_markdown:
+            write_json_artifact(capture.id, "server_parsed_markdown.json", content_markdown)
 
-        artifact_urls = self._build_artifact_urls(request, capture.id, bool(enrichment_blob))
+        artifact_urls = self._build_artifact_urls(
+            request,
+            capture.id,
+            bool(enrichment_blob),
+            bool(content_markdown),
+        )
 
         refs_qs = capture.references.all()[:3]
         summary = {

--- a/paperclip/tests/test_api_helpers.py
+++ b/paperclip/tests/test_api_helpers.py
@@ -18,6 +18,7 @@ pytest.importorskip("bs4")
 
 import paperclip.api as api_module
 from paperclip.api import (
+    _content_sections_to_markdown_paragraphs,
     _enrich_reference_objs_with_doi,
     _reference_to_server_view,
     apply_doi_enrichment,
@@ -57,6 +58,61 @@ def test_reference_to_server_view_preserves_fields_and_adds_alias() -> None:
 
     # Original reference should remain untouched by alias injection
     assert "id" not in reference
+
+
+def test_content_sections_to_markdown_paragraphs_simplifies_structure() -> None:
+    content = {
+        "abstract": [
+            {"title": "Summary", "body": "Overview of findings."},
+            {"body": ""},
+        ],
+        "body": [
+            {
+                "title": "Introduction",
+                "markdown": "Intro paragraph.\n\nSecond intro paragraph.",
+                "paragraphs": [
+                    {"markdown": "Intro paragraph.", "sentences": []},
+                    {"markdown": "Second intro paragraph.", "sentences": []},
+                    {"markdown": "", "sentences": []},
+                ],
+                "children": [
+                    {
+                        "title": "Background",
+                        "paragraphs": [
+                            {"markdown": "Background details.", "sentences": []},
+                        ],
+                    },
+                    "ignored",
+                ],
+            }
+        ],
+        "keywords": [" methods ", "", "results"],
+    }
+
+    simplified = _content_sections_to_markdown_paragraphs(content)
+
+    assert simplified == {
+        "abstract": [
+            {"title": "Summary", "paragraphs": ["Overview of findings."]},
+        ],
+        "body": [
+            {
+                "title": "Introduction",
+                "markdown": "Intro paragraph.\n\nSecond intro paragraph.",
+                "paragraphs": [
+                    "Intro paragraph.",
+                    "Second intro paragraph.",
+                ],
+                "children": [
+                    {
+                        "title": "Background",
+                        "paragraphs": ["Background details."],
+                    }
+                ],
+            }
+        ],
+        "keywords": ["methods", "results"],
+    }
 
 
 def _sample_csl() -> dict:

--- a/paperclip/tests/test_api_helpers.py
+++ b/paperclip/tests/test_api_helpers.py
@@ -99,7 +99,6 @@ def test_content_sections_to_markdown_paragraphs_simplifies_structure() -> None:
         "body": [
             {
                 "title": "Introduction",
-                "markdown": "Intro paragraph.\n\nSecond intro paragraph.",
                 "paragraphs": [
                     "Intro paragraph.",
                     "Second intro paragraph.",
@@ -142,14 +141,25 @@ def test_build_markdown_capture_view_orders_metadata_and_references() -> None:
         content=content,
         meta=meta,
         references=cast(Sequence[Mapping[str, Any]], references),
+        title="Sample",
     )
 
-    assert list(view.keys()) == ["metadata", "abstract", "body", "keywords", "references"]
+    assert list(view.keys()) == [
+        "metadata",
+        "abstract",
+        "body",
+        "keywords",
+        "markdown",
+        "references",
+    ]
     assert view["metadata"] == meta
     assert view["abstract"][0]["paragraphs"] == ["Overview."]
     assert view["body"][0]["paragraphs"] == ["Paragraph one."]
     assert len(view["references"]) == 2
     assert view["references"][0]["ref_id"] == "ref-1"
+    markdown = view["markdown"]
+    assert markdown.startswith("## Metadata")
+    assert "## References" in markdown
 
 
 def _sample_csl() -> dict:

--- a/paperclip/tests/test_api_helpers.py
+++ b/paperclip/tests/test_api_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import threading
 from types import SimpleNamespace
-from typing import Any, Iterable, cast
+from typing import Any, Iterable, Mapping, Sequence, cast
 
 import pytest
 
@@ -18,6 +18,7 @@ pytest.importorskip("bs4")
 
 import paperclip.api as api_module
 from paperclip.api import (
+    _build_markdown_capture_view,
     _content_sections_to_markdown_paragraphs,
     _enrich_reference_objs_with_doi,
     _reference_to_server_view,
@@ -113,6 +114,42 @@ def test_content_sections_to_markdown_paragraphs_simplifies_structure() -> None:
         ],
         "keywords": ["methods", "results"],
     }
+
+
+def test_build_markdown_capture_view_orders_metadata_and_references() -> None:
+    content = {
+        "abstract": [
+            {"title": "Summary", "body": "Overview."},
+        ],
+        "keywords": ["science"],
+        "body": [
+            {
+                "title": "Intro",
+                "paragraphs": [
+                    {"markdown": "Paragraph one."},
+                ],
+            }
+        ],
+    }
+    meta = {"title": "Sample", "authors": ["Doe"]}
+    references = [
+        {"ref_id": "ref-1", "raw": "Reference 1."},
+        "ignored",
+        {"ref_id": "ref-2", "raw": "Reference 2."},
+    ]
+
+    view = _build_markdown_capture_view(
+        content=content,
+        meta=meta,
+        references=cast(Sequence[Mapping[str, Any]], references),
+    )
+
+    assert list(view.keys()) == ["metadata", "abstract", "body", "keywords", "references"]
+    assert view["metadata"] == meta
+    assert view["abstract"][0]["paragraphs"] == ["Overview."]
+    assert view["body"][0]["paragraphs"] == ["Paragraph one."]
+    assert len(view["references"]) == 2
+    assert view["references"][0]["ref_id"] == "ref-1"
 
 
 def _sample_csl() -> dict:


### PR DESCRIPTION
## Summary
- add a helper that reduces parsed content sections to markdown-only paragraphs
- expose the markdown-only view in the capture artifacts and API response metadata
- cover the transformation with a unit test

## Testing
- pytest paperclip/tests/test_api_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d198469058832985230bd05beca9d0